### PR TITLE
Adatbázis inicializálása

### DIFF
--- a/avallama/App.axaml.cs
+++ b/avallama/App.axaml.cs
@@ -7,6 +7,7 @@ using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Data.Core.Plugins;
 using System.Linq;
+using System.Threading.Tasks;
 using avallama.Constants;
 using Avalonia.Markup.Xaml;
 using avallama.Services;
@@ -14,6 +15,7 @@ using avallama.ViewModels;
 using avallama.Views;
 using Avalonia.Controls;
 using Avalonia.Styling;
+using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace avallama;
@@ -22,7 +24,8 @@ public partial class App : Application
 {
     private OllamaService? _ollamaService;
     private DialogService? _dialogService;
-    
+    private DatabaseInitService? _databaseInitService;
+    public static SqliteConnection SharedDbConnection { get; private set; } = null!;
     public override void Initialize()
     {
         AvaloniaXamlLoader.Load(this);
@@ -39,6 +42,8 @@ public partial class App : Application
         
         _ollamaService = services.GetRequiredService<OllamaService>();
         _dialogService = services.GetRequiredService<DialogService>();
+        _databaseInitService = services.GetRequiredService<DatabaseInitService>();
+        SharedDbConnection = Task.Run(() => _databaseInitService.GetOpenConnectionAsync()).GetAwaiter().GetResult();
         
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {

--- a/avallama/ServiceCollectionExtensions.cs
+++ b/avallama/ServiceCollectionExtensions.cs
@@ -17,7 +17,7 @@ public static class ServiceCollectionExtensions
         // Dependencyk létrehozása
         // Singleton - Memóriában folytonosan jelen van
         // Transient - Csak akkor hozza létre amikor szükség van rá és ha nincs akkor törli
-        
+        collection.AddSingleton<DatabaseInitService>();
         collection.AddSingleton<OllamaService>();
         collection.AddSingleton<DialogService>();
         collection.AddSingleton<LocalizationService>();

--- a/avallama/Services/DatabaseInitService.cs
+++ b/avallama/Services/DatabaseInitService.cs
@@ -1,0 +1,99 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Data.Sqlite;
+
+namespace avallama.Services;
+
+public class DatabaseInitService : IDatabaseInitService
+{
+    private readonly string _dbPath;
+
+    public DatabaseInitService()
+    {
+        var exeDir = AppContext.BaseDirectory;
+        _dbPath = Path.Combine(exeDir, "avallama.db");
+    }
+
+    public async Task<SqliteConnection> GetOpenConnectionAsync()
+    {
+        var isNew = !File.Exists(_dbPath);
+
+        var connection = new SqliteConnection($"Data Source={_dbPath}");
+        await connection.OpenAsync();
+
+        if (isNew) await InitializeSchemaAsync(connection);
+
+        var isValid = await IsDatabaseValidAsync(connection);
+        var hasRequiredTables = await DoesTableExistAsync(connection, "conversations") &&
+                                await DoesTableExistAsync(connection, "messages");
+
+        if (!isValid || !hasRequiredTables)
+        {
+            // Ezt a hibat esetleg egy debug logba vagy valahogy mashogy meg lehetne jeleniteni
+            Console.WriteLine(
+                "Database file is present but either corrupted or missing required tables. Reinitializing.");
+            await InitializeSchemaAsync(connection);
+        }
+
+        return connection;
+    }
+
+    private async Task InitializeSchemaAsync(SqliteConnection conn)
+    {
+        var cmd = conn.CreateCommand();
+        cmd.CommandText = """
+                          PRAGMA foreign_keys = ON;
+
+                          CREATE TABLE IF NOT EXISTS conversations (
+                          id TEXT PRIMARY KEY,
+                          title TEXT NOT NULL,
+                          created_at TEXT NOT NULL,
+                          last_message_sent_at TEXT
+                          );
+
+                          CREATE TABLE IF NOT EXISTS messages (
+                          id INTEGER PRIMARY KEY AUTOINCREMENT,
+                          conversation_id TEXT NOT NULL,
+                          role TEXT NOT NULL,
+                          message TEXT NOT NULL,
+                          timestamp TEXT NOT NULL,
+                          model_name TEXT,
+                          tokens_per_sec REAL,
+                          FOREIGN KEY (conversation_id) REFERENCES conversations(id) ON DELETE CASCADE
+                          );
+
+                          CREATE INDEX IF NOT EXISTS idx_messages_convo_timestamp
+                          ON messages (conversation_id, timestamp);
+
+                          CREATE INDEX IF NOT EXISTS idx_conversations_last_msg
+                          ON conversations (last_message_sent_at);
+                          """;
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    private static async Task<bool> IsDatabaseValidAsync(SqliteConnection conn)
+    {
+        try
+        {
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = "PRAGMA integrity_check;";
+            var result = (string?)await cmd.ExecuteScalarAsync();
+
+            return result == "ok";
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+    }
+
+    public static async Task<bool> DoesTableExistAsync(SqliteConnection connection, string tableName)
+    {
+        await using var cmd = connection.CreateCommand();
+        cmd.CommandText = "SELECT name FROM sqlite_master WHERE type='table' AND name=@name;";
+        cmd.Parameters.AddWithValue("@name", tableName);
+        var result = await cmd.ExecuteScalarAsync();
+        return result != null;
+    }
+}

--- a/avallama/Services/IDatabaseInitService.cs
+++ b/avallama/Services/IDatabaseInitService.cs
@@ -1,0 +1,9 @@
+using System.Threading.Tasks;
+using Microsoft.Data.Sqlite;
+
+namespace avallama.Services;
+
+public interface IDatabaseInitService
+{
+    Task<SqliteConnection> GetOpenConnectionAsync();
+}


### PR DESCRIPTION
https://github.com/4foureyes/avallamaplanning/issues/58

Létrehoztam a `DatabaseInitService.cs`-t ami minden induláskor ellenőrzi, hogy 

1. Van-e .db fájl, ha nincs akkor készít egyet és inicializálja,
2. Szerkezetileg megfelelő-e a db az SQLite beépített `integrity_check` utasításával,
3. Megvan-e a két szükséges tábla ami kell a müködéshez.

Ha a 2-es vagy 3-as pont nem teljesül, akkor újrainicializálja az adatbázist.

**Lokális teszteléshez (Riderben):**
Egyszer futtasd le az appot, majd a Rideren belül hozz létre egy db kapcsolatot. A db a `/bin/Debug/net9.0/avallama.db` útvonalon található (ha pedig telepítve van, akkor a telepített alkalmazás mappájában). Így le tudod tesztelni az adatbázis létrejöttét, illetve a helyreállítást.