### PR TITLE
New conversation button now creates new conversation on UI and in db

### DIFF
--- a/avallama/Models/Conversation.cs
+++ b/avallama/Models/Conversation.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Márk Csörgő and Martin Bartos
 // Licensed under the MIT License. See LICENSE file for details.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -13,6 +14,7 @@ public class Conversation : ObservableObject
     private string _model = string.Empty;
     private int _messageCountToRegenerateTitle;
     private ObservableCollection<Message> _messages = [];
+    private Guid _conversationId = Guid.Empty;
 
     public string Title
     {
@@ -36,6 +38,12 @@ public class Conversation : ObservableObject
     {
         get => _messageCountToRegenerateTitle;
         set => SetProperty(ref _messageCountToRegenerateTitle, value);
+    }
+
+    public Guid ConversationId
+    {
+        get => _conversationId;
+        set => SetProperty(ref _conversationId, value);
     }
     
     public Conversation(string title, string model)

--- a/avallama/ServiceCollectionExtensions.cs
+++ b/avallama/ServiceCollectionExtensions.cs
@@ -17,7 +17,8 @@ public static class ServiceCollectionExtensions
         // Dependencyk létrehozása
         // Singleton - Memóriában folytonosan jelen van
         // Transient - Csak akkor hozza létre amikor szükség van rá és ha nincs akkor törli
-        collection.AddSingleton<DatabaseInitService>();
+        collection.AddTransient<DatabaseInitService>();
+        collection.AddSingleton<DatabaseService>();
         collection.AddSingleton<OllamaService>();
         collection.AddSingleton<DialogService>();
         collection.AddSingleton<LocalizationService>();

--- a/avallama/Services/DatabaseInitService.cs
+++ b/avallama/Services/DatabaseInitService.cs
@@ -5,6 +5,11 @@ using Microsoft.Data.Sqlite;
 
 namespace avallama.Services;
 
+public interface IDatabaseInitService
+{
+    Task<SqliteConnection> GetOpenConnectionAsync();
+}
+
 public class DatabaseInitService : IDatabaseInitService
 {
     private readonly string _dbPath;

--- a/avallama/Services/DatabaseService.cs
+++ b/avallama/Services/DatabaseService.cs
@@ -1,0 +1,40 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Data.Sqlite;
+
+namespace avallama.Services;
+
+public interface IDatabaseService
+{
+    //TODO i guess
+}
+
+public class DatabaseService : IDatabaseService
+{
+    private readonly string _dbPath;
+
+    public DatabaseService()
+    {
+        var exeDir = AppContext.BaseDirectory;
+        _dbPath = Path.Combine(exeDir, "avallama.db");
+    }
+
+    public async Task<Guid> CreateConversation()
+    {
+        var conversationId = Guid.NewGuid();
+
+        await using var connection = new SqliteConnection($"Data Source={_dbPath}");
+        await connection.OpenAsync();
+        
+        var cmd = connection.CreateCommand();
+        cmd.CommandText = "INSERT INTO conversations (id, title, created_at, last_message_sent_at) VALUES (@Id, @Title, @CreatedAt, @LastMessageSentAt)";
+        cmd.Parameters.AddWithValue("@Id", conversationId);
+        cmd.Parameters.AddWithValue("@Title", LocalizationService.GetString("NEW_CONVERSATION"));
+        cmd.Parameters.AddWithValue("@CreatedAt", DateTime.Now);
+        cmd.Parameters.AddWithValue("@LastMessageSentAt", DateTime.Now);
+        
+        await cmd.ExecuteNonQueryAsync();
+        return conversationId;
+    }
+}

--- a/avallama/Services/IDatabaseInitService.cs
+++ b/avallama/Services/IDatabaseInitService.cs
@@ -1,9 +1,0 @@
-using System.Threading.Tasks;
-using Microsoft.Data.Sqlite;
-
-namespace avallama.Services;
-
-public interface IDatabaseInitService
-{
-    Task<SqliteConnection> GetOpenConnectionAsync();
-}

--- a/avallama/Styles/Button.axaml
+++ b/avallama/Styles/Button.axaml
@@ -138,29 +138,48 @@ Licensed under the MIT License. See LICENSE file for details.
     </Style>
     
     <!-- thank you bmartin -->
-    <Style Selector="Button.avallamaWhite"> 
-        <Setter Property="IsEnabled" Value="False"/>
+    <Style Selector="Button.avallamaWhite">
+        <Setter Property="Background" Value="{DynamicResource Primary}" />
+        <Setter Property="Foreground" Value="{DynamicResource OnPrimary}" />
+        <Setter Property="Transitions">
+            <Setter.Value>
+                <Transitions>
+                    <BrushTransition Property="Foreground" Duration="0:0:0.05" />
+                    <BrushTransition Property="Background" Duration="0:0:0.05" />
+                </Transitions>
+            </Setter.Value>
+        </Setter>
         <Setter Property="Template">
             <Setter.Value>
-                <ControlTemplate>
-                    <Border Background="{DynamicResource OutlineVariant}"
+                <ControlTemplate TargetType="Button">
+                    <Border Background="{TemplateBinding Background}"
                             CornerRadius="8"
-                            Padding="14,8" HorizontalAlignment="Stretch">
-                        <StackPanel Orientation="Horizontal" Spacing="10" HorizontalAlignment="Center">
+                            Padding="14,8">
+                        <StackPanel Orientation="Horizontal"
+                                    Spacing="10"
+                                    HorizontalAlignment="Center">
                             <controls:DynamicSvg Path="/Assets/Svg/avallama-logo-white.svg"
-                                                 Width="8" FillColor="{DynamicResource OnSurfaceVariant}"
-                                                 HorizontalAlignment="Center"/>
-                            <ContentPresenter
-                                Content="{TemplateBinding Content}"
-                                Foreground="{DynamicResource OnSurfaceVariant}"
-                                VerticalAlignment="Center"
-                                FontSize="10"/>
+                                                 Width="8"
+                                                 FillColor="{TemplateBinding Foreground}" />
+                            <TextBlock Text="{TemplateBinding Content}"
+                                       Foreground="{TemplateBinding Foreground}"
+                                       FontSize="10"
+                                       Background="{TemplateBinding Background}"
+                                       VerticalAlignment="Center"/>
                         </StackPanel>
                     </Border>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
     </Style>
+
+    <Style Selector="Button.avallamaWhite:pointerover">
+        <Setter Property="Foreground" Value="{DynamicResource OnPrimaryContainer}" />
+        <Setter Property="Background" Value="{DynamicResource PrimaryContainer}" />
+    </Style>
+
+
+
     
     <Style Selector="Button.secondaryButton">
         <Setter Property="Background" Value="{DynamicResource Secondary}"/>

--- a/avallama/Utilities/ObservableStack.cs
+++ b/avallama/Utilities/ObservableStack.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.ObjectModel;
+
+namespace avallama.Utilities;
+
+public class ObservableStack<T> : ObservableCollection<T>
+{
+    public void Push(T item)
+    {
+        Insert(0, item);
+    }
+    
+    public T Pop()
+    {
+        if (Count == 0)
+            throw new InvalidOperationException("Stack is empty");
+
+        var item = this[0];
+        RemoveAt(0);
+        return item;
+    }
+    
+    public T Peek()
+    {
+        if (Count == 0)
+            throw new InvalidOperationException("Stack is empty");
+
+        return this[0];
+    }
+}

--- a/avallama/ViewModels/HomeViewModel.cs
+++ b/avallama/ViewModels/HomeViewModel.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using avallama.Constants;
 using avallama.Models;
 using avallama.Services;
+using avallama.Utilities;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 
@@ -23,12 +24,13 @@ public partial class HomeViewModel : PageViewModel
     private readonly OllamaService _ollamaService;
     private readonly DialogService _dialogService;
     private readonly ConfigurationService _configurationService;
+    private readonly DatabaseService _databaseService;
 
     public string ScrollSetting;
 
-    private ObservableCollection<Conversation> _conversations;
+    private ObservableStack<Conversation> _conversations;
     
-    public ObservableCollection<Conversation> Conversations
+    public ObservableStack<Conversation> Conversations
     {
         get => _conversations;
         set => SetProperty(ref _conversations, value);
@@ -84,6 +86,18 @@ public partial class HomeViewModel : PageViewModel
             true,
             700
         );
+    }
+
+    [RelayCommand]
+    public async Task CreateNewConversation()
+    {
+        var newConversation = new Conversation(
+            LocalizationService.GetString("NEW_CONVERSATION"),
+            "llama3.2"
+        );
+        Conversations.Push(newConversation);
+        SelectedConversation = newConversation;
+        SelectedConversation.ConversationId = await _databaseService.CreateConversation();
     }
 
     private async Task AddGeneratedMessage()
@@ -165,13 +179,14 @@ public partial class HomeViewModel : PageViewModel
         await GetModelInfo(AvailableModels.FirstOrDefault() ?? "llama3.2").WaitAsync(TimeSpan.FromMilliseconds(100));
     }
     
-    public HomeViewModel(OllamaService ollamaService, DialogService dialogService, ConfigurationService configurationService)
+    public HomeViewModel(OllamaService ollamaService, DialogService dialogService, ConfigurationService configurationService, DatabaseService databaseService)
     {
         // beállítás, hogy a viewmodel milyen paget kezel
         Page = ApplicationPage.Home;
         _dialogService = dialogService;
         _ollamaService = ollamaService;
         _configurationService = configurationService;
+        _databaseService = databaseService;
         
         LoadSettings();
         

--- a/avallama/Views/HomeView.axaml
+++ b/avallama/Views/HomeView.axaml
@@ -36,12 +36,11 @@ Licensed under the MIT License. See LICENSE file for details.
               RowDefinitions="Auto,*,Auto"
               Background="{DynamicResource SurfaceContainer}">
             <Grid Grid.Row="0" ColumnDefinitions="2.5*, 6*" x:Name="SideBarTopGrid" Margin="10">
-                <Border Grid.Column="0"
-                        ToolTip.Tip="{localization:LocalizationService Key='CONVERSATIONS_NOT_AVAILABLE'}">
+                <Border Grid.Column="0">
                     <Button x:Name="NewConversationBtn" Classes="avallamaWhite"
                             Content="{localization:LocalizationService Key='NEW'}"
                             Margin="0,0,10,0" HorizontalAlignment="Stretch" Cursor="Hand"
-                            IsEnabled="False" />
+                            IsEnabled="True" Command="{Binding CreateNewConversation}" />
                 </Border>
                 <TextBox Grid.Column="1" Watermark="{localization:LocalizationService Key='SEARCH'}" MaxLines="1">
                     <TextBox.InnerRightContent>


### PR DESCRIPTION
https://github.com/4foureyes/avallamaplanning/issues/59

Mostmár `Enabled` az új beszélgetések gomb, ennek a kinézetét kicsit meg kellett változtassam. Amikor rányomsz akkor egy új beszélgetés jön létre ami Pusholásra kerül az új `ObservableStack` (lsd lejjebb) típusu Conversationsbe, tehát rákerül a UI-ra, és beszúrásra kerül a DB-be, egyenlőre ennyi, a többi funkcionalítás kövi issuekba jön.

`ObservableStack`: Mivel az oldalsó sávban a beszúrandó beszélgetés a sáv tetejére kell hogy kerüljön, Pusholni akartam a collectionbe, de nincs ilyen funkciója, tehát csináltam egy extensiont az `ObservableCollection`-nek, ami a veremnek szokásos műveleteit is tudja (Push, Pop, Peek). Szerintem máshol is hasznos lehet majd a jövőben