### PR TITLE
Added partial multiple model support, setup tests and CI, added editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# EditorConfig is awesome: https://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,79 @@
+name: Build and Test
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    name: Build and Test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      DOTNET_CLI_TELEMETRY_OPTOUT: "1"
+      DOTNET_NOLOGO: "true"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET 9 SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Display dotnet info
+        run: dotnet --info
+
+      - name: Restore
+        run: dotnet restore avallama.sln
+
+      - name: Build (Release)
+        run: dotnet build avallama.sln --configuration Release --no-restore
+
+      - name: Test (Release) with coverage
+        run: >-
+          dotnet test avallama.sln
+          --configuration Release
+          --no-build
+          --collect:"XPlat Code Coverage"
+          --logger "trx;LogFileName=test-results.trx"
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-${{ matrix.os }}
+          path: |
+            **/TestResults/*.trx
+            **/TestResults/*
+
+      - name: Upload coverage artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ matrix.os }}
+          path: |
+            **/TestResults/*/coverage.cobertura.xml
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: "**/TestResults/*/coverage.cobertura.xml"
+          flags: ${{ matrix.os }}
+          verbose: true
+          fail_ci_if_error: false

--- a/README.md
+++ b/README.md
@@ -3,6 +3,15 @@
 </p>
 <h1 align="center">Avallama</h1>
 
+<p align="center">
+  <a href="https://github.com/eyeonspringfield/avallama/actions/workflows/pr.yml">
+    <img alt="Build" src="https://github.com/eyeonspringfield/avallama/actions/workflows/pr.yml/badge.svg?branch=main">
+  </a>
+  <a href="https://codecov.io/gh/eyeonspringfield/avallama">
+    <img alt="Coverage" src="https://codecov.io/gh/eyeonspringfield/avallama/branch/main/graph/badge.svg">
+  </a>
+</p>
+
 
 <p align="center">A cross-platform local AI desktop app powered by Ollama</p>
 

--- a/avallama.Tests/.gitignore
+++ b/avallama.Tests/.gitignore
@@ -1,0 +1,3 @@
+/TestResults/
+/obj/
+/bin/

--- a/avallama.Tests/ConfigurationServiceTests.cs
+++ b/avallama.Tests/ConfigurationServiceTests.cs
@@ -1,0 +1,28 @@
+using avallama.Services;
+using Xunit;
+
+namespace avallama.Tests;
+
+public class ConfigurationServiceTests
+{
+    [Fact]
+    public void ReadSetting_UnknownKey_ReturnsEmptyString()
+    {
+        var svc = new ConfigurationService();
+        var value = svc.ReadSetting("__nonexistent_key__");
+        Assert.Equal(string.Empty, value);
+    }
+
+    [Fact]
+    public void SaveSetting_ThenReadSetting_ReturnsSavedValue()
+    {
+        var svc = new ConfigurationService();
+        var key = "unit-test-key";
+        var expected = "unit-test-value";
+
+        svc.SaveSetting(key, expected);
+        var actual = svc.ReadSetting(key);
+
+        Assert.Equal(expected, actual);
+    }
+}

--- a/avallama.Tests/GuideItemTests.cs
+++ b/avallama.Tests/GuideItemTests.cs
@@ -1,0 +1,38 @@
+using avallama.Models;
+using Xunit;
+
+namespace avallama.Tests;
+
+public class GuideItemTests
+{
+    [Fact]
+    public void Constructor_SetsProperties_WithDescription()
+    {
+        var item = new GuideItem("Title", "img/path.png", "Desc");
+        Assert.Equal("Title", item.Title);
+        Assert.Equal("img/path.png", item.ImageSource);
+        Assert.Equal("Desc", item.Description);
+    }
+
+    [Fact]
+    public void Constructor_SetsProperties_WithoutDescription()
+    {
+        var item = new GuideItem("A", "B");
+        Assert.Equal("A", item.Title);
+        Assert.Equal("B", item.ImageSource);
+        Assert.Null(item.Description);
+    }
+
+    [Fact]
+    public void Properties_AreMutable()
+    {
+        var item = new GuideItem("T", "I");
+        item.Title = "T2";
+        item.ImageSource = "I2";
+        item.Description = "D2";
+
+        Assert.Equal("T2", item.Title);
+        Assert.Equal("I2", item.ImageSource);
+        Assert.Equal("D2", item.Description);
+    }
+}

--- a/avallama.Tests/ObservableStackTests.cs
+++ b/avallama.Tests/ObservableStackTests.cs
@@ -1,0 +1,42 @@
+using System;
+using avallama.Utilities;
+using Xunit;
+
+namespace avallama.Tests;
+
+public class ObservableStackTests
+{
+    [Fact]
+    public void PushAndPop_ShouldMaintainLifoOrder()
+    {
+        var stack = new ObservableStack<int>();
+        stack.Push(1);
+        stack.Push(2);
+        stack.Push(3);
+
+        Assert.Equal(3, stack.Count);
+        Assert.Equal(3, stack.Pop());
+        Assert.Equal(2, stack.Pop());
+        Assert.Equal(1, stack.Pop());
+        Assert.Empty(stack);
+    }
+
+    [Fact]
+    public void Peek_ShouldReturnTopWithoutRemoving()
+    {
+        var stack = new ObservableStack<string>();
+        stack.Push("a");
+        stack.Push("b");
+
+        var top = stack.Peek();
+        Assert.Equal("b", top);
+        Assert.Equal(2, stack.Count);
+    }
+
+    [Fact]
+    public void Pop_OnEmpty_ShouldThrow()
+    {
+        var stack = new ObservableStack<int>();
+        Assert.Throws<InvalidOperationException>(() => stack.Pop());
+    }
+}

--- a/avallama.Tests/RenderHelperTests.cs
+++ b/avallama.Tests/RenderHelperTests.cs
@@ -1,0 +1,32 @@
+using avallama.Utilities;
+using Xunit;
+
+namespace avallama.Tests;
+
+public class RenderHelperTests
+{
+    [Fact]
+    public void GetSizeInGb_ZeroBytes()
+    {
+        var result = RenderHelper.GetSizeInGb(0);
+        Assert.Equal("0 GB", result);
+    }
+
+    [Fact]
+    public void GetSizeInGb_OneGiB()
+    {
+        long gib = 1024L * 1024 * 1024;
+        var result = RenderHelper.GetSizeInGb(gib);
+        Assert.Equal("1 GB", result);
+    }
+
+    [Fact]
+    public void GetSizeInGb_OnePointFiveGiB()
+    {
+        long gib = 1024L * 1024 * 1024;
+        long size = gib * 3 / 2; // 1.5 GiB
+        var result = RenderHelper.GetSizeInGb(size);
+        Assert.Equal("1.5 GB", result);
+    }
+}
+

--- a/avallama.Tests/avallama.Tests.csproj
+++ b/avallama.Tests/avallama.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\avallama\avallama.csproj" />
+  </ItemGroup>
+</Project>
+

--- a/avallama.sln
+++ b/avallama.sln
@@ -1,8 +1,9 @@
-﻿
-Microsoft Visual Studio Solution File, Format Version 12.00
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "avallama", "avallama\avallama.csproj", "{71F69597-EBB7-487D-9B4F-432FB1D459D9}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "avallama.helper", "avallama.helper\avallama.helper.csproj", "{CF493CAD-7EA3-4FCD-9E5F-C800986E2318}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "avallama.Tests", "avallama.Tests\avallama.Tests.csproj", "{6C1C6AE2-BB4C-49D8-9A71-9D840E5C1C4B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -38,6 +39,18 @@ Global
 		{CF493CAD-7EA3-4FCD-9E5F-C800986E2318}.Release|x64.Build.0 = Release|Any CPU
 		{CF493CAD-7EA3-4FCD-9E5F-C800986E2318}.Release|x86.ActiveCfg = Release|Any CPU
 		{CF493CAD-7EA3-4FCD-9E5F-C800986E2318}.Release|x86.Build.0 = Release|Any CPU
+		{6C1C6AE2-BB4C-49D8-9A71-9D840E5C1C4B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6C1C6AE2-BB4C-49D8-9A71-9D840E5C1C4B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6C1C6AE2-BB4C-49D8-9A71-9D840E5C1C4B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{6C1C6AE2-BB4C-49D8-9A71-9D840E5C1C4B}.Debug|x64.Build.0 = Debug|Any CPU
+		{6C1C6AE2-BB4C-49D8-9A71-9D840E5C1C4B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6C1C6AE2-BB4C-49D8-9A71-9D840E5C1C4B}.Debug|x86.Build.0 = Debug|Any CPU
+		{6C1C6AE2-BB4C-49D8-9A71-9D840E5C1C4B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6C1C6AE2-BB4C-49D8-9A71-9D840E5C1C4B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6C1C6AE2-BB4C-49D8-9A71-9D840E5C1C4B}.Release|x64.ActiveCfg = Release|Any CPU
+		{6C1C6AE2-BB4C-49D8-9A71-9D840E5C1C4B}.Release|x64.Build.0 = Release|Any CPU
+		{6C1C6AE2-BB4C-49D8-9A71-9D840E5C1C4B}.Release|x86.ActiveCfg = Release|Any CPU
+		{6C1C6AE2-BB4C-49D8-9A71-9D840E5C1C4B}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/avallama/Assets/Localization/Resources.hu.resx
+++ b/avallama/Assets/Localization/Resources.hu.resx
@@ -397,4 +397,7 @@ Licensed under the MIT License. See LICENSE file for details.
     <data name="DATABASE_ERROR_OCCURRED" xml:space="preserve">
         <value>Hiba történt az adatbázis művelet során: </value>
     </data>
+    <data name="ERROR_DELETING_MODEL" xml:space="preserve">
+        <value>Hiba történt a modell törlése során.</value>
+    </data>
 </root>

--- a/avallama/Assets/Localization/Resources.resx
+++ b/avallama/Assets/Localization/Resources.resx
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 
-<!-- 
+<!--
 Copyright (c) Márk Csörgő and Martin Bartos
 Licensed under the MIT License. See LICENSE file for details.
 -->
@@ -8,7 +8,7 @@ Licensed under the MIT License. See LICENSE file for details.
 <root>
     <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <xsd:element name="root" msdata:IsDataSet="true">
-            
+
         </xsd:element>
     </xsd:schema>
     <resheader name="resmimetype">
@@ -403,5 +403,8 @@ Licensed under the MIT License. See LICENSE file for details.
     </data>
     <data name="DATABASE_ERROR_OCCURRED" xml:space="preserve">
         <value>A database error has occurred: </value>
+    </data>
+    <data name="ERROR_DELETING_MODEL" xml:space="preserve">
+        <value>Error occurred deleting model.</value>
     </data>
 </root>

--- a/avallama/Dtos/OllamaShowResponse.cs
+++ b/avallama/Dtos/OllamaShowResponse.cs
@@ -1,0 +1,16 @@
+namespace avallama.Dtos;
+
+public sealed class OllamaShowResponse
+{
+    public string? Parameters { get; set; }
+    public long Size { get; set; }
+    public OllamaDetails? Details { get; set; }
+
+    public sealed class OllamaDetails
+    {
+        public string? Format { get; set; }
+        public string? Quantization { get; set; }
+        public string? Family { get; set; }
+        public int? ContextLength { get; set; }
+    }
+}

--- a/avallama/Dtos/OllamaTagsResponse.cs
+++ b/avallama/Dtos/OllamaTagsResponse.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+
+namespace avallama.Dtos;
+
+public class OllamaTagsResponse
+{
+    public List<OllamaTagsModel> Models { get; set; } = new();
+}
+
+// I don't know why these classes are "never instantiated" but it is used in deserialization
+public class OllamaTagsModel
+{
+    public string? Name { get; set; }
+    public string? Model { get; set; }
+    // ReSharper disable once InconsistentNaming
+    public DateTime? Modified_At { get; set; }
+    public long? Size { get; set; }
+    public string? Digest { get; set; }
+    public OllamaModelDetails? Details { get; set; }
+}
+
+public class OllamaModelDetails
+{
+    // ReSharper disable once InconsistentNaming
+    public string? Parent_Model { get; set; }
+    public string? Format { get; set; }
+    public string? Family { get; set; }
+    public List<string>? Families { get; set; }
+    // ReSharper disable once InconsistentNaming
+    public string? Parameter_Size { get; set; }
+    // ReSharper disable once InconsistentNaming
+    public string? Quantization_Level { get; set; }
+}

--- a/avallama/Models/ChatRequest.cs
+++ b/avallama/Models/ChatRequest.cs
@@ -9,16 +9,16 @@ namespace avallama.Models;
 
 public class ChatRequest
 {
-    //igazabol itt lehetne dinamikusan beallitani a modellt majd
     [JsonPropertyName("model")]
-    public string Model { get; set; } = "llama3.2";
+    public string Model { get; set; }
 
     [JsonPropertyName("messages")]
     public List<ChatMessage> Messages { get; set; }
 
-    public ChatRequest(List<Message> messages)
+    public ChatRequest(List<Message> messages, string model)
     {
         Messages = ConvertToChatMessages(messages);
+        Model = model;
     }
 
     private static List<ChatMessage> ConvertToChatMessages(List<Message> messages)

--- a/avallama/Models/LibraryModel.cs
+++ b/avallama/Models/LibraryModel.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+
+namespace avallama.Models;
+
+public class LibraryModel
+{
+    public string Name { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public long PullCount { get; set; }
+    public IList<string> PopularTags { get; set; } = new List<string>();
+    public int TagCount { get; set; }
+    public string LastUpdated { get; set; } = string.Empty;
+}

--- a/avallama/Services/DatabaseService.cs
+++ b/avallama/Services/DatabaseService.cs
@@ -165,7 +165,6 @@ public class DatabaseService : IDatabaseService
         var idsParam = string.Join(",", enumerable.Select((_, i) => $"@id{i}"));
         await using var cmd = connection.CreateCommand();
         cmd.CommandText = $"""
-
                                    SELECT conversation_id, model_name
                                    FROM messages
                                    WHERE conversation_id IN ({idsParam})

--- a/avallama/Utilities/LibraryScraper.cs
+++ b/avallama/Utilities/LibraryScraper.cs
@@ -1,0 +1,126 @@
+// Copyright (c) Márk Csörgő and Martin Bartos
+// Licensed under the MIT License. See LICENSE file for details.
+
+using avallama.Models;
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+using HtmlAgilityPack;
+
+namespace avallama.Utilities;
+
+public class LibraryScraper(HttpClient httpClient)
+{
+    public async Task<List<LibraryModel>> ListModelsFromLibraryAsync()
+    {
+        const string url = "https://ollama.com/library";
+        HttpResponseMessage response;
+        try
+        {
+            response = await httpClient.GetAsync(url);
+        }
+        catch (HttpRequestException)
+        {
+            return [];
+        }
+
+        if (!response.IsSuccessStatusCode)
+        {
+            return [];
+        }
+
+        var html = await response.Content.ReadAsStringAsync();
+        var doc = new HtmlDocument();
+        doc.LoadHtml(html);
+
+        var results = new List<LibraryModel>();
+
+        var nodeSelector = doc.DocumentNode.SelectNodes("//*[@id='repo']/ul/li/a");
+
+        foreach (var aNode in nodeSelector)
+        {
+            try
+            {
+                var info = new LibraryModel();
+
+                var nameNode = aNode.SelectSingleNode("div/h2/div/span");
+                info.Name = nameNode.InnerText.Trim();
+
+                var descNode = aNode.SelectSingleNode("div/p");
+                info.Description = descNode.InnerText.Trim();
+
+                // Pull count: “div:nth-of-type(2) > p > span:first-of-type > span:first-of-type”
+                var secondDiv = aNode.SelectSingleNode("div[2]");
+                var pInSecondDiv = secondDiv.SelectSingleNode("p");
+                var span1 = pInSecondDiv.SelectSingleNode("span");
+                var span1Inner = span1.SelectSingleNode("span");
+                var pullText = span1Inner.InnerText.Trim();
+
+                info.PullCount = ParsePullCount(pullText);
+
+                var spanTagCount = pInSecondDiv.SelectSingleNode("span[2]/span");
+                if (int.TryParse(spanTagCount.InnerText.Trim(), out var tagCount))
+                    info.TagCount = tagCount;
+
+
+                // Last updated: third span etc.
+                var lastUpdatedNode = pInSecondDiv.SelectSingleNode("span[3]/span[2]");
+                info.LastUpdated = lastUpdatedNode.InnerText.Trim();
+
+                // Popular tags: list of span under div > div > span
+                // e.g., tags are shown in some nested span set
+                var tagSpanNodes = aNode.SelectNodes("div/div/span");
+
+                var tags = new List<string>();
+                foreach (var tagSpan in tagSpanNodes)
+                {
+                    var t = tagSpan.InnerText.Trim();
+                    if (!string.IsNullOrEmpty(t))
+                        tags.Add(t);
+                }
+
+                info.PopularTags = tags;
+
+
+                results.Add(info);
+            }
+            catch (Exception)
+            {
+                // skip and move on
+            }
+        }
+
+        return results;
+    }
+
+    private long ParsePullCount(string s)
+    {
+        // e.g., "1.5M", "120K", "100", "2.3B" etc.
+        s = s.Trim().ToUpperInvariant();
+        double multiplier = 1;
+        if (s.EndsWith('B'))
+        {
+            multiplier = 1_000_000_000;
+            s = s[..^1];
+        }
+        else if (s.EndsWith('M'))
+        {
+            multiplier = 1_000_000;
+            s = s[..^1];
+        }
+        else if (s.EndsWith('K'))
+        {
+            multiplier = 1_000;
+            s = s[..^1];
+        }
+
+        if (double.TryParse(s, System.Globalization.NumberStyles.AllowDecimalPoint,
+                System.Globalization.CultureInfo.InvariantCulture, out double value))
+        {
+            return (long)(value * multiplier);
+        }
+
+        return 0;
+    }
+}

--- a/avallama/Views/HomeView.axaml
+++ b/avallama/Views/HomeView.axaml
@@ -112,20 +112,7 @@ Licensed under the MIT License. See LICENSE file for details.
                       VerticalAlignment="Center"
                       ItemsSource="{Binding AvailableModels}"
                       SelectedItem="{Binding CurrentlySelectedModel, Mode=TwoWay}"
-                      IsEnabled="False" />
-
-            <!-- Letöltés gomb -->
-            <Button VerticalAlignment="Center"
-                    Padding="6"
-                    IsVisible="{Binding IsNotDownloadedVisible}"
-                    IsEnabled="{Binding !IsDownloading}"
-                    Background="{DynamicResource Primary}"
-                    Command="{Binding DownloadModel}"
-                    Cursor="Hand">
-                <controls:DynamicSvg Path="/Assets/Svg/download.svg"
-                                     StrokeColor="{DynamicResource OnPrimary}"
-                                     Width="20" />
-            </Button>
+                      IsEnabled="{Binding IsModelsLoaded}" />
         </StackPanel>
 
         <!-- Tájékoztató szövegek -->

--- a/avallama/avallama.csproj
+++ b/avallama/avallama.csproj
@@ -29,22 +29,23 @@ Licensed under the MIT License. See LICENSE file for details.
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Avalonia" Version="11.3.4" />
-        <PackageReference Include="Avalonia.Desktop" Version="11.3.4" />
-        <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.4" />
-        <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.4" />
+        <PackageReference Include="Avalonia" Version="11.3.6" />
+        <PackageReference Include="Avalonia.Desktop" Version="11.3.6" />
+        <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.6" />
+        <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.6" />
         
         <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-        <PackageReference Include="Avalonia.Diagnostics" Version="11.3.4">
+        <PackageReference Include="Avalonia.Diagnostics" Version="11.3.6">
             <IncludeAssets Condition="'$(Configuration)' != 'Debug'">None</IncludeAssets>
             <PrivateAssets Condition="'$(Configuration)' != 'Debug'">All</PrivateAssets>
         </PackageReference>
+        <PackageReference Include="HtmlAgilityPack" Version="1.12.3" />
         
-        <PackageReference Include="Svg.Controls.Avalonia" Version="11.3.0.3" />
+        <PackageReference Include="Svg.Controls.Avalonia" Version="11.3.6.2" />
         <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
-        <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.8" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.8" />
-        <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="9.0.8" />
+        <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.9" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.9" />
+        <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="9.0.9" />
     </ItemGroup>
 
     <ItemGroup>

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,38 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "0..100"
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 2%
+        informational: true
+    patch:
+      default:
+        target: 60%
+        threshold: 1%
+        informational: true
+
+ignore:
+  - "**/bin/**"
+  - "**/obj/**"
+  - "avallama/Assets/**"
+  - "nativelibs/**"
+  - "**/*.g.cs"
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false
+
+github_checks:
+  annotations: true
+
+flags:
+  windows: {}
+  ubuntu: {}
+  macos: {}


### PR DESCRIPTION
Changes:
- Added partial support for multiple models:
    -  This can be tested effectively by downloading multiple models through the ollama CLI, and then deleting and redownloading them through the model manager
    - Downloading functionality has been partially removed from the home viewmodel, and moved to the model manager, but still needs to be fixed on the UI side
    - Downloaded models can be selected from the dropdown menu at the top of a conversation, which is only enabled once downloaded models are checked
    - The model manager now displays details about downloaded models, in addition to scraping model information from the ollama website, the latter functionality is only partial and needs to be fixed on the UI side
- Setup tests and CI:
    - Created the `avallama.Tests` project and wrote some basic tests, this can be easily expanded on in the future
    - Setup GH actions to run tests on each commit to main, and each PR, where it will be a requirement to have tests pass to merge the PR
    - Setup code coverage results, which in the future can also be turned on to require a certain coverage to merge PRs
    - Added badges of the GH workflow and code coverage to the README
- Updated dependencies:
    - I updated all dependencies to the latest stable version
- Added editorconfig:
    - Added a `.editorconfig` file to enforce specific styling across editors 