### PR TITLE
Fixed model dropdown when no dropdown, added CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+@bmartin042503 @eyeonspringfield

--- a/avallama.Tests/Fixtures/TestServicesFixture.cs
+++ b/avallama.Tests/Fixtures/TestServicesFixture.cs
@@ -1,0 +1,14 @@
+using avallama.Services;
+using CommunityToolkit.Mvvm.Messaging;
+using Moq;
+
+namespace avallama.Tests.Fixtures;
+
+public class TestServicesFixture
+{
+    public Mock<IOllamaService> OllamaMock { get; } = new();
+    public Mock<IDialogService> DialogMock { get; } = new();
+    public Mock<IConfigurationService> ConfigMock { get; } = new();
+    public Mock<IDatabaseService> DbMock { get; } = new();
+    public Mock<IMessenger> MessengerMock { get; } = new();
+}

--- a/avallama.Tests/ViewModels/HomeViewModelTests.cs
+++ b/avallama.Tests/ViewModels/HomeViewModelTests.cs
@@ -1,0 +1,111 @@
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+using avallama.Models;
+using avallama.Services;
+using avallama.Tests.Fixtures;
+using avallama.Utilities;
+using avallama.ViewModels;
+using avallama.Views;
+using Avalonia.Controls;
+using Moq;
+using Xunit;
+using Avalonia.Headless.XUnit;
+
+namespace avallama.Tests.ViewModels;
+
+public class HomeViewModelTests(TestServicesFixture fixture) : IClassFixture<TestServicesFixture>
+{
+    private void DbMock()
+    {
+        // Mock db svc to prevent NullReferenceException when testing
+        fixture.DbMock.Setup(db => db.GetConversations())
+            .ReturnsAsync([]);
+    }
+
+    [Fact]
+    public async Task InitializeModels_WhenNonEmptyList_HasItems_SelectedLastModel_DropdownEnabled()
+    {
+        fixture.OllamaMock.Reset();
+        var models = new ObservableCollection<OllamaModel>
+        {
+            new OllamaModel { Name = "model1" },
+            new OllamaModel { Name = "model2" }
+        };
+        fixture.OllamaMock
+            .Setup(o => o.ListDownloaded())
+            .ReturnsAsync(models);
+        DbMock();
+
+        var vm = new HomeViewModel(
+            fixture.OllamaMock.Object,
+            fixture.DialogMock.Object,
+            fixture.ConfigMock.Object,
+            fixture.DbMock.Object,
+            fixture.MessengerMock.Object
+        );
+
+        var availableModels = new ObservableCollection<string>{
+            "model1",
+            "model2"
+        };
+
+        await vm.InitializeModels();
+
+        Assert.Equal(availableModels, vm.AvailableModels);
+        Assert.Equal("model2", vm.CurrentlySelectedModel);
+        Assert.True(vm.IsModelsDropdownEnabled);
+    }
+
+    [Fact]
+    public async Task InitializeModels_WhenEmptyList_IsEmpty_SelectedEmptyString_DropdownDisabled()
+    {
+        fixture.OllamaMock.Reset();
+        fixture.OllamaMock
+            .Setup(o => o.ListDownloaded())
+            .ReturnsAsync([]);
+        DbMock();
+
+        var vm = new HomeViewModel(
+            fixture.OllamaMock.Object,
+            fixture.DialogMock.Object,
+            fixture.ConfigMock.Object,
+            fixture.DbMock.Object,
+            fixture.MessengerMock.Object
+        );
+
+        await vm.InitializeModels();
+
+        Assert.Single(vm.AvailableModels);
+        Assert.Equal(LocalizationService.GetString("NO_MODELS_FOUND"), vm.CurrentlySelectedModel);
+        Assert.False(vm.IsModelsDropdownEnabled);
+
+    }
+
+    [AvaloniaFact]
+    public async Task View_WhenEmptyModelsList_DisablesComboBox()
+    {
+        fixture.OllamaMock.Setup(o => o.ListDownloaded())
+            .ReturnsAsync([]);
+        DbMock();
+
+        var vm = new HomeViewModel(
+            fixture.OllamaMock.Object,
+            fixture.DialogMock.Object,
+            fixture.ConfigMock.Object,
+            fixture.DbMock.Object,
+            fixture.MessengerMock.Object);
+
+        var view = new HomeView { DataContext = vm };
+
+        await vm.InitializeModels();
+
+        var combo = view.FindControl<ComboBox>("ModelsComboBox");
+        var warning = view.FindControl<TextBlock>("NoModelsWarningTextBlock");
+
+        Assert.NotNull(combo);
+        Assert.NotNull(warning);
+        Assert.False(combo.IsEnabled);
+        Assert.False(combo.IsDropDownOpen);
+        Assert.True(warning.IsVisible);
+    }
+}

--- a/avallama.Tests/avallama.Tests.csproj
+++ b/avallama.Tests/avallama.Tests.csproj
@@ -7,6 +7,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="Avalonia.Headless.Xunit" Version="11.3.4" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
@@ -16,6 +18,12 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+      <None Include="../nativelibs/macos/libFullScreenCheck.dylib">
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
   </ItemGroup>
 
   <ItemGroup>

--- a/avallama/App.axaml.cs
+++ b/avallama/App.axaml.cs
@@ -30,7 +30,7 @@ public partial class App : Application
     {
         AvaloniaXamlLoader.Load(this);
     }
-    
+
     public override void OnFrameworkInitializationCompleted()
     {
         // Az összes dependency létrehozása és eltárolása egy ServiceCollectionben
@@ -39,46 +39,46 @@ public partial class App : Application
 
         // ServiceProvider ami biztosítja a létrehozott dependencyket
         var services = collection.BuildServiceProvider();
-        
+
         // nem lehet semmilyen dependency lekérés a ConfigurationService előtt
         // különben nem lesznek jól megjelenítve a lokalizált szövegek, színek
         // a lokalizáció a rendszer nyelve alapján állítódik be, ezt kell felülírni a ConfigurationService-el
-        
+
         // nyelv és színséma lekérdezése, beállítása
         var configurationService = services.GetRequiredService<ConfigurationService>();
-        
+
         var colorScheme = configurationService.ReadSetting(ConfigurationKey.ColorScheme);
         var language = configurationService.ReadSetting(ConfigurationKey.Language);
-        
+
         var showInformationalMessages = configurationService.ReadSetting(ConfigurationKey.ShowInformationalMessages);
-        
+
         // új felhasználóknak alapértelmezetten bekapcsoljuk a tájékoztató üzeneteket
         if (string.IsNullOrWhiteSpace(showInformationalMessages))
         {
             configurationService.SaveSetting(ConfigurationKey.ShowInformationalMessages, true.ToString());
         }
-        
+
         var cultureInfo = language switch
         {
             "hungarian" => CultureInfo.GetCultureInfo("hu-HU"),
             _ => CultureInfo.InvariantCulture
         };
-        
+
         RequestedThemeVariant = colorScheme switch
         {
             "dark" => ThemeVariant.Dark,
             "light" => ThemeVariant.Light,
             _ => ThemeVariant.Default
         };
-            
+
         LocalizationService.ChangeLanguage(cultureInfo);
-        
+
         var appService = services.GetRequiredService<IApplicationService>();
         _ollamaService = services.GetRequiredService<OllamaService>();
         _dialogService = services.GetRequiredService<DialogService>();
         _databaseInitService = services.GetRequiredService<DatabaseInitService>();
         SharedDbConnection = Task.Run(() => _databaseInitService.GetOpenConnectionAsync()).GetAwaiter().GetResult();
-        
+
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
             //feliratkozunk az OnStartup-ra és az OnExitre
@@ -86,7 +86,7 @@ public partial class App : Application
             desktop.Exit += OnExit;
             desktop.ShutdownMode = ShutdownMode.OnMainWindowClose;
 
-            // Avoid duplicate validations from both Avalonia and the CommunityToolkit. 
+            // Avoid duplicate validations from both Avalonia and the CommunityToolkit.
             // More info: https://docs.avaloniaui.net/docs/guides/development-guides/data-validation#manage-validationplugins
             DisableAvaloniaDataAnnotationValidation();
             appService.InitializeMainWindow();
@@ -130,7 +130,7 @@ public partial class App : Application
             BindingPlugins.DataValidators.Remove(plugin);
         }
     }
-    
+
     private void About_OnClick(object? sender, EventArgs e)
     {
         // ezt később majd vmi fancy dialogra

--- a/avallama/Assets/Localization/Resources.hu.resx
+++ b/avallama/Assets/Localization/Resources.hu.resx
@@ -74,10 +74,10 @@ Licensed under the MIT License. See LICENSE file for details.
         <value>Generálás folyamatban...</value>
     </data>
     <data name="NOT_DOWNLOADED_WARNING" xml:space="preserve">
-        <value>A modell nincs letöltve</value>
+        <value>Nincs letöltött modell, tölts le modellt a Modellkezelő felületen</value>
     </data>
     <data name="LOADING_MODELS" xml:space="preserve">
-        <value>Modellek betöltése...</value>
+        <value>Modellek töltése...</value>
     </data>
     <data name="STARTING_DOWNLOAD" xml:space="preserve">
         <value>Letöltés indítása...</value>
@@ -275,7 +275,7 @@ Licensed under the MIT License. See LICENSE file for details.
         <value>Kérlek add meg a szerver IP címét és portját</value>
     </data>
     <data name="NO_MODELS_FOUND" xml:space="preserve">
-        <value>Nincs megjeleníthető modell</value>
+        <value>Nincs modell</value>
     </data>
     <data name="NO_CONNECTION_DOWNLOAD" xml:space="preserve">
         <value>Nincs kapcsolat a letöltéshez</value>

--- a/avallama/Assets/Localization/Resources.resx
+++ b/avallama/Assets/Localization/Resources.resx
@@ -81,7 +81,7 @@ Licensed under the MIT License. See LICENSE file for details.
         <value>Generating response...</value>
     </data>
     <data name="NOT_DOWNLOADED_WARNING" xml:space="preserve">
-        <value>Model is not downloaded</value>
+        <value>No downloaded models found, download models through the Model Manager</value>
     </data>
     <data name="LOADING_MODELS" xml:space="preserve">
         <value>Loading models...</value>

--- a/avallama/Extensions/ServiceCollectionExtensions.cs
+++ b/avallama/Extensions/ServiceCollectionExtensions.cs
@@ -18,24 +18,34 @@ public static class ServiceCollectionExtensions
         // Dependencyk létrehozása
         // Singleton - Memóriában folytonosan jelen van
         // Transient - Csak akkor hozza létre amikor szükség van rá és ha nincs akkor törli
-        
+
         // ciklikus függőségre vigyázni kell, mert megeshet hogy nem dob kivételt, nem hoz létre semmit de mégis fut az alkalmazás
         // és nehezen lehet debuggolni, pl. AppService -> MainViewModel -> PageFactory -> Func<...> -> HomeViewModel -> AppService
-        
+
         // TODO: ezeket majd talán jobban "interfészesíteni" hogy tesztelésnél könnyebb legyen
-        
+
         // gyenge referenciás messenger, ami azt jelenti hogy nem kell manuálisan törölni őket
         collection.AddSingleton<IMessenger>(WeakReferenceMessenger.Default);
-        
-        collection.AddSingleton<IApplicationService, ApplicationService>();
+
+        // Temporary registration of both interfaces and concrete implementations until refactoring is done
+        collection.AddSingleton<ApplicationService>();
+        collection.AddSingleton<IApplicationService>(sp => sp.GetRequiredService<ApplicationService>());
+
         collection.AddSingleton<ConfigurationService>();
-        
+        collection.AddSingleton<IConfigurationService>(sp => sp.GetRequiredService<ConfigurationService>());
+
         collection.AddTransient<DatabaseInitService>();
+        collection.AddTransient<IDatabaseInitService>(sp => sp.GetRequiredService<DatabaseInitService>());
+
         collection.AddSingleton<DatabaseService>();
+        collection.AddSingleton<IDatabaseService>(sp => sp.GetRequiredService<DatabaseService>());
 
         collection.AddSingleton<OllamaService>();
+        collection.AddSingleton<IOllamaService>(sp => sp.GetRequiredService<OllamaService>());
+
         collection.AddSingleton<DialogService>();
-        
+        collection.AddSingleton<IDialogService>(sp => sp.GetRequiredService<DialogService>());
+
         collection.AddSingleton<MainViewModel>();
         collection.AddSingleton<HomeViewModel>();
         collection.AddTransient<GreetingViewModel>();
@@ -58,13 +68,13 @@ public static class ServiceCollectionExtensions
             ApplicationPage.ModelManager => serviceProvider.GetRequiredService<ModelManagerViewModel>(),
             _ => throw new InvalidOperationException() // ha még nincs adott Page regisztrálva akkor kivétel
         });
-        
-         
+
+
         collection.AddSingleton<Func<ApplicationDialog, DialogViewModel>>(serviceProvider => content => content switch
         {
             // mivel a dialogok át lettek helyezve ezért kivételt dob, de ezt nem törölném hisz lehet még később olyan view
             // ami személyre szabott és külön ablakban kell megjelennie dialogként
-            _ => throw new NotSupportedException() 
+            _ => throw new NotSupportedException()
             // Info, Error és a többi dialog nem kell, mert azok nem hívják meg ezt
         });
     }

--- a/avallama/Services/OllamaService.cs
+++ b/avallama/Services/OllamaService.cs
@@ -23,7 +23,10 @@ using Avalonia.Threading;
 
 namespace avallama.Services;
 
-internal interface IOllamaService
+// egy delegate ahol megadjuk hogy milyen metódus definícióval kell rendelkezniük a feliratkozó metódusoknak
+public delegate void ServiceStatusChangedHandler(ServiceStatus? status, string? message);
+
+public interface IOllamaService
 {
     Task Start();
     void Stop();
@@ -32,6 +35,13 @@ internal interface IOllamaService
     Task<string> GetModelParamNum(string modelName);
     IAsyncEnumerable<DownloadResponse> PullModel(string modelName);
     IAsyncEnumerable<OllamaResponse> GenerateMessage(List<Message> messageHistory, string modelName);
+    Task<bool> IsOllamaServerRunning();
+    Task<List<OllamaModel>> ListLibraryModelsAsOllamaModelsAsync();
+    Task<bool> DeleteModel(string modelName);
+    Task<ObservableCollection<OllamaModel>> ListDownloaded();
+    ServiceStatus? CurrentServiceStatus { get; }
+    string? CurrentServiceMessage { get; }
+    event ServiceStatusChangedHandler? ServiceStatusChanged;
 }
 
 public class OllamaService : IOllamaService
@@ -44,9 +54,6 @@ public class OllamaService : IOllamaService
     public string? CurrentServiceMessage { get; private set; }
     private string OllamaPath { get; set; }
     private HttpClient _httpClient;
-
-    // egy delegate ahol megadjuk hogy milyen metódus definícióval kell rendelkezniük a feliratkozó metódusoknak
-    public delegate void ServiceStatusChangedHandler(ServiceStatus? status, string? message);
 
     // az event létrehozása, ami ugye az előzőleg létrehozott delegate típusú, tehát a megfelelő szignatúrájú metódusok
     // tudnak feliratkozni rá

--- a/avallama/Views/HomeView.axaml
+++ b/avallama/Views/HomeView.axaml
@@ -1,4 +1,4 @@
-﻿<!-- 
+﻿<!--
 Copyright (c) Márk Csörgő and Martin Bartos
 Licensed under the MIT License. See LICENSE file for details.
 -->
@@ -112,7 +112,7 @@ Licensed under the MIT License. See LICENSE file for details.
                       VerticalAlignment="Center"
                       ItemsSource="{Binding AvailableModels}"
                       SelectedItem="{Binding CurrentlySelectedModel, Mode=TwoWay}"
-                      IsEnabled="{Binding IsModelsLoaded}" />
+                      IsEnabled="{Binding IsModelsDropdownEnabled}" Name="ModelsComboBox"/>
         </StackPanel>
 
         <!-- Tájékoztató szövegek -->
@@ -162,15 +162,16 @@ Licensed under the MIT License. See LICENSE file for details.
 
             <!-- Modell nincs letöltve szöveg -->
             <Grid ColumnDefinitions="Auto,*" ColumnSpacing="4" HorizontalAlignment="Center"
-                  IsVisible="{Binding IsNotDownloadedVisible}">
+                  IsVisible="{Binding IsNoModelsDownloadedVisible}">
                 <controls:DynamicSvg Grid.Column="0" Path="/Assets/Svg/info.svg"
                                      FillColor="{DynamicResource Error}"
                                      Width="18" />
 
-                <TextBlock Grid.Column="1" Text="{Binding NotDownloadedWarning}"
+                <TextBlock Grid.Column="1" Text="{Binding NoModelsDownloadedWarning}"
                            Foreground="{DynamicResource Error}"
                            TextAlignment="Left"
-                           TextWrapping="Wrap" />
+                           TextWrapping="Wrap"
+                           Name="NoModelsWarningTextBlock" />
             </Grid>
         </StackPanel>
 

--- a/avallama/avallama.csproj
+++ b/avallama/avallama.csproj
@@ -1,4 +1,4 @@
-﻿<!-- 
+﻿<!--
 Copyright (c) Márk Csörgő and Martin Bartos
 Licensed under the MIT License. See LICENSE file for details.
 -->
@@ -29,19 +29,19 @@ Licensed under the MIT License. See LICENSE file for details.
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Avalonia" Version="11.3.6" />
-        <PackageReference Include="Avalonia.Desktop" Version="11.3.6" />
-        <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.6" />
-        <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.6" />
-        
+        <PackageReference Include="Avalonia" Version="11.3.4" />
+        <PackageReference Include="Avalonia.Desktop" Version="11.3.4" />
+        <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.4" />
+        <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.4" />
+
         <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-        <PackageReference Include="Avalonia.Diagnostics" Version="11.3.6">
+        <PackageReference Include="Avalonia.Diagnostics" Version="11.3.4">
             <IncludeAssets Condition="'$(Configuration)' != 'Debug'">None</IncludeAssets>
             <PrivateAssets Condition="'$(Configuration)' != 'Debug'">All</PrivateAssets>
         </PackageReference>
         <PackageReference Include="HtmlAgilityPack" Version="1.12.3" />
-        
-        <PackageReference Include="Svg.Controls.Avalonia" Version="11.3.6.2" />
+
+        <PackageReference Include="Svg.Controls.Avalonia" Version="11.3.0.4" />
         <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
         <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.9" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.9" />
@@ -62,5 +62,5 @@ Licensed under the MIT License. See LICENSE file for details.
     <ItemGroup>
       <Folder Include="Assets\Images\" />
     </ItemGroup>
-    
+
 </Project>


### PR DESCRIPTION
Fixes https://github.com/4foureyes/avallamaplanning/issues/73

Changes:
- Added a CODEOWNERS file
- Fixed the bug causing the dropdown menu to contain nothing and be enabled when a user does not have any models downloaded
- Added tests for this behavior (which needed a small refactoring of `HomeViewModel.cs` and `ServiceCollectionExtentions.cs`)
- Repurposed a now unneeded "model not downloaded" warning message to display a warning message if no models downloaded
- Also added no model downloaded warning to the ComboBox itself, for if a user has warnings turned off
- To fit into the ComboBox, hungarian localization needed to be shortened
- Fixed (hopefully) bug described by Bmartin in the discussion, tested on Debian and worked as expected.