### PR TITLE
Fix security issues in release.yml, fix Arch Linux build step

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -71,7 +71,7 @@ jobs:
             **/TestResults/*/coverage.cobertura.xml
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7
         with:
           files: "**/TestResults/*/coverage.cobertura.xml"
           flags: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,14 @@ on:
       - 'v*'
   workflow_dispatch:
 
+env:
+  DOTNET_CLI_TELEMETRY_OPTOUT: "1"
+  DOTNET_NOLOGO: "true"
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: "1"
+
+permissions:
+  contents: read
+
 jobs:
   build-windows:
     name: Windows Installer (.exe)
@@ -42,7 +50,7 @@ jobs:
           name: AvallamaSetup.exe
           path: scripts\AvallamaSetup.exe
 
-  build-linux:
+  build-debian:
     name: Debian Package (.deb)
     runs-on: ubuntu-latest
 
@@ -68,13 +76,13 @@ jobs:
           name: linux-packages
           path: |
             avallama_${{ env.VERSION }}_amd64.deb
-  
+
   build-arch:
     name: Arch Package (.pkg.tar.zst)
     runs-on: ubuntu-latest
     container:
       image: archlinux:latest
-    
+
     steps:
       - name: Install base build tools and .NET
         run: |
@@ -84,27 +92,32 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v4
 
+      - name: Dotnet workload restore
+        run: dotnet workload restore ./avallama/avallama.csproj
+
       - name: Set version var
         run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV
 
       - name: Run Arch packaging script
         run: |
-          chmod +x scripts/package-arch.sh
-          ./scripts/package-arch.sh "${{ env.VERSION }}"
+          useradd -m builder
+          mkdir -p /tmp/build
+          cp -r avallama /tmp/build/
+          cp -r scripts /tmp/build/
+          chown -R builder:builder /tmp/build
+          sudo -u builder bash -c "cd /tmp/build && chmod +x scripts/package-arch.sh && scripts/package-arch.sh '${{ env.VERSION }}'"
 
-      - name: Upload Arch Tarball and PKGBUILD
+      - name: Upload Arch Package
         uses: actions/upload-artifact@v4
         with:
-          name: arch-tarball-pkgbuild
-          path: |
-            avallama_${{ env.VERSION }}_arch_x64.tar.gz
-            PKGBUILD
-  
-  
+          name: arch-package
+          path: /tmp/build/*.pkg.tar.zst
+
+
   build-macos:
     name: macOS Packages (.zip for x64 and arm64)
     runs-on: macos-latest
-    
+
     steps:
       - uses: actions/checkout@v4
 
@@ -136,8 +149,11 @@ jobs:
 
   release:
     name: Publish GitHub Release
-    needs: [ build-windows, build-linux, build-macos ]
+    needs: [ build-windows, build-debian, build-arch, build-macos ]
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@v4
@@ -163,7 +179,7 @@ jobs:
           find artifacts -type f -exec cp {} release-assets/ \;
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@aec2ec56f94eb8180ceec724245f64ef008b89f5
         with:
           tag_name: ${{ github.ref_name }}
           name: ${{ github.ref_name }}

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ We are currently not accepting outside contributions, however we encourage users
 
 #### Debian/Ubuntu (x64)
 1. Download the latest .deb package from the [releases](https://github.com/4foureyes/avallama/releases) page.
-2. Open a terminal and navigate to the directory where the file was downloaded, for example: 
+2. Open a terminal and navigate to the directory where the file was downloaded, for example:
 ```bash
 cd ~/Downloads
 ```
@@ -64,11 +64,24 @@ sudo apt remove avallama
 
 This installation method has not been verified and may run unexpectedly.
 
-1. Download the latest PKGBUILD and .tar.gz files from the [releases](https://github.com/4foureyes/avallama/releases) page.
+1. Download the latest .pkg.tar.zst from the Releases tab
 2. Open a terminal and navigate to the directory where the files were downloaded.
 3. Install the package using the following command:
 ```bash
-makepkg -si
+sudo pacman -U avallama-0.2.0-1-x86_64.pkg.tar.zst
+```
+*Replace `avallama-0.2.0-1-x86_64.pkg.tar.zst` with the correct filename of the latest package*
+
+
+To uninstall run:
+
+```bash
+sudo pacman -R avallama
+```
+
+To uninstall and remove config files
+```bash
+sudo pacman -Rns avallama
 ```
 
 ### Windows (x64)


### PR DESCRIPTION
Fixes https://github.com/4foureyes/avallamaplanning/issues/53 
Fixes https://github.com/4foureyes/avallamaplanning/issues/82

Changes:
 - Fixed the security issues that CodeQL issued warnings about by adding permissions to the workflows and pinning 3rd party workflows to a specific commit hash
 - Fixed the Arch Linux build step in the release pipeline and manually verified that the package works (besides the permissions issue which will be addressed in https://github.com/4foureyes/avallamaplanning/issues/84)
 - Updated the Arch installation steps in `README.md` but didn't remove the non-functional install part since this won't be released yet