### PR TITLE
Optimize DatabaseService, fix permission issues on Linux

### DIFF
--- a/avallama.Tests/Controls/TextHelperTests.cs
+++ b/avallama.Tests/Controls/TextHelperTests.cs
@@ -11,7 +11,7 @@ using Avalonia.Media.TextFormatting;
 using Xunit;
 using Colors = Avalonia.Media.Colors;
 
-namespace avallama.Tests;
+namespace avallama.Tests.Controls;
 
 public class TextHelperTests
 {

--- a/avallama.Tests/Controls/TextSelectionTests.cs
+++ b/avallama.Tests/Controls/TextSelectionTests.cs
@@ -4,7 +4,7 @@
 using avallama.Controls;
 using Xunit;
 
-namespace avallama.Tests;
+namespace avallama.Tests.Controls;
 
 public class TextSelectionTests
 {

--- a/avallama.Tests/Models/GuideItemTests.cs
+++ b/avallama.Tests/Models/GuideItemTests.cs
@@ -4,7 +4,7 @@
 using avallama.Models;
 using Xunit;
 
-namespace avallama.Tests;
+namespace avallama.Tests.Models;
 
 public class GuideItemTests
 {

--- a/avallama.Tests/Services/ConfigurationServiceTests.cs
+++ b/avallama.Tests/Services/ConfigurationServiceTests.cs
@@ -4,7 +4,7 @@
 using avallama.Services;
 using Xunit;
 
-namespace avallama.Tests;
+namespace avallama.Tests.Services;
 
 public class ConfigurationServiceTests
 {

--- a/avallama.Tests/Services/DatabaseInitServiceTests.cs
+++ b/avallama.Tests/Services/DatabaseInitServiceTests.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using avallama.Services;
+using avallama.Tests.Extensions;
+using Xunit;
+
+namespace avallama.Tests.Services;
+
+public class DatabaseInitServiceTests
+{
+
+    [Fact]
+    public async Task InitializeSchemaAsync_DoesNotThrow()
+    {
+        var service = new DatabaseInitService(isTest: true);
+        await AsyncAssertExtensions.DoesNotThrowAsync(async () =>
+        {
+            await using var conn = await service.GetOpenConnectionAsync();
+            Assert.NotNull(conn);
+            Assert.Equal(System.Data.ConnectionState.Open, conn.State);
+        });
+    }
+
+    [Fact]
+    public async Task InitializeSchemaAsync_CreatesShemaMetadata_WithCorrectHash()
+    {
+        var service = new DatabaseInitService();
+
+        await using var conn = await service.GetOpenConnectionAsync();
+
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = "SELECT value FROM schema_metadata WHERE key = 'schema_hash'";
+        var hash = await cmd.ExecuteScalarAsync() as string;
+
+        Assert.NotNull(hash);
+        Assert.NotEmpty(hash);
+        Assert.Equal(128, hash.Length);
+    }
+
+    [Fact]
+    public async Task InitializeSchemaAsync_MessagesIndex_IsUsed_WhenQueryingMessages_ForConversation()
+    {
+        var service = new DatabaseInitService(isTest: true);
+        await using var conn = await service.GetOpenConnectionAsync();
+
+        await using (var insertCmd = conn.CreateCommand())
+        {
+            insertCmd.CommandText = """
+                              INSERT INTO conversations (id, title, created_at, last_message_sent_at)
+                              VALUES ('conv-1', 'Test', '2024-01-01T00:00:00Z', '2024-01-01T01:00:00Z');
+
+                              INSERT INTO messages (conversation_id, role, message, timestamp)
+                              VALUES ('conv-1', 'user', 'Test', '2024-01-01T00:00:00Z');
+                              """;
+            await insertCmd.ExecuteNonQueryAsync();
+        }
+
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = "EXPLAIN QUERY PLAN SELECT * FROM messages WHERE conversation_id = 'conv-1' ORDER BY timestamp";
+        await using var reader = await cmd.ExecuteReaderAsync();
+
+        var queryPlan = new List<string>();
+        while (await reader.ReadAsync())
+        {
+            queryPlan.Add(reader.GetString(3));
+        }
+
+        var planText = string.Join(" ", queryPlan);
+        Assert.Contains("idx_messages_convo_timestamp", planText, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task InitializeSchemaAsync_ConversationsIndex_IsUsed_WhenQueryingByLastMessage()
+    {
+        var service = new DatabaseInitService(isTest: true);
+        await using var conn = await service.GetOpenConnectionAsync();
+
+        await using (var insertCmd = conn.CreateCommand())
+        {
+            insertCmd.CommandText = """
+                                    INSERT INTO conversations (id, title, created_at, last_message_sent_at)
+                                    VALUES ('conv-1', 'Test', '2024-01-01T00:00:00Z', '2024-01-01T01:00:00Z');
+                                    """;
+            await insertCmd.ExecuteNonQueryAsync();
+        }
+
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = "EXPLAIN QUERY PLAN SELECT * FROM conversations WHERE last_message_sent_at IS NOT NULL ORDER BY last_message_sent_at DESC";
+        await using var reader = await cmd.ExecuteReaderAsync();
+
+        var queryPlan = new List<string>();
+        while (await reader.ReadAsync())
+        {
+            queryPlan.Add(reader.GetString(3));
+        }
+
+        var planText = string.Join(" ", queryPlan);
+        Assert.Contains("idx_conversations_last_msg", planText, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/avallama.Tests/Services/DatabaseServiceTests.cs
+++ b/avallama.Tests/Services/DatabaseServiceTests.cs
@@ -1,0 +1,291 @@
+// Copyright (c) Márk Csörgő and Martin Bartos
+// Licensed under the MIT License. See LICENSE file for details.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using avallama.Models;
+using avallama.Services;
+using avallama.Tests.Fixtures;
+using Microsoft.Data.Sqlite;
+using Xunit;
+
+namespace avallama.Tests.Services;
+
+public class DatabaseServiceTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly DatabaseService _databaseService;
+
+    public DatabaseServiceTests()
+    {
+
+        _connection = new SqliteConnection("Data Source=:memory:");
+        _connection.Open();
+
+        InitializeTestSchema(_connection);
+
+        _databaseService = new DatabaseService(_connection);
+    }
+
+    private static void InitializeTestSchema(SqliteConnection connection)
+    {
+        var cmd = connection.CreateCommand();
+        cmd.CommandText = """
+                          PRAGMA foreign_keys = ON;
+                          PRAGMA journal_mode = WAL;
+                          PRAGMA synchronous = NORMAL;
+                          PRAGMA temp_store = MEMORY;
+                          PRAGMA cache_size = 32000;
+
+                          CREATE TABLE IF NOT EXISTS conversations (
+                          id TEXT PRIMARY KEY,
+                          title TEXT NOT NULL,
+                          created_at TEXT NOT NULL,
+                          last_message_sent_at TEXT
+                          );
+
+                          CREATE TABLE IF NOT EXISTS messages (
+                          id INTEGER PRIMARY KEY AUTOINCREMENT,
+                          conversation_id TEXT NOT NULL,
+                          role TEXT NOT NULL,
+                          message TEXT NOT NULL,
+                          timestamp TEXT NOT NULL,
+                          model_name TEXT,
+                          tokens_per_sec REAL,
+                          FOREIGN KEY (conversation_id) REFERENCES conversations(id) ON DELETE CASCADE
+                          );
+
+                          CREATE INDEX IF NOT EXISTS idx_messages_convo_timestamp
+                          ON messages (conversation_id, timestamp);
+
+                          CREATE INDEX IF NOT EXISTS idx_conversations_last_msg
+                          ON conversations (last_message_sent_at);
+                          """;
+        cmd.ExecuteNonQuery();
+    }
+
+    // Conversation tests
+
+    [Fact]
+    public async Task CreateConversation_ShouldComplete_Within100ms()
+    {
+        var conversation = new Conversation(Guid.AllBitsSet, "Test Conversation", new List<Message>());
+        var stopwatch = Stopwatch.StartNew();
+        await _databaseService.CreateConversation(conversation);
+        stopwatch.Stop();
+
+        Assert.True(stopwatch.ElapsedMilliseconds < 100, $"Operation took too long: {stopwatch.ElapsedMilliseconds}ms");
+    }
+
+    [Fact]
+    public async Task GetMessagesForConversation_ShouldReturnMessagesInOrder()
+    {
+        var id = await _databaseService.CreateConversation(
+            new Conversation(Guid.Empty, "Test", new List<Message>()));
+
+        await _databaseService.InsertMessage(id, new Message("First"), null, null);
+        await Task.Delay(10);
+        await _databaseService.InsertMessage(id, new GeneratedMessage("Second", 50.0), "model", 50.0);
+        await Task.Delay(10);
+        await _databaseService.InsertMessage(id, new Message("Third"), null, null);
+
+        var messages = await _databaseService.GetMessagesForConversation(
+            new Conversation(id, "Test", new List<Message>()));
+
+        Assert.Equal(3, messages.Count);
+        Assert.Equal("First", messages[0].Content);
+        Assert.Equal("Second", messages[1].Content);
+        Assert.Equal("Third", messages[2].Content);
+        Assert.IsType<GeneratedMessage>(messages[1]);
+    }
+
+    [Fact]
+    public async Task GetMessagesForConversation_WithNoMessages_ShouldReturnEmpty()
+    {
+        var id = await _databaseService.CreateConversation(
+            new Conversation(Guid.Empty, "Empty", new List<Message>()));
+
+        var messages = await _databaseService.GetMessagesForConversation(
+            new Conversation(id, "Empty", new List<Message>()));
+
+        Assert.Empty(messages);
+    }
+
+    [Fact]
+    public async Task GetConversations_ShouldOrderByLastMessage()
+    {
+        var id1 = await _databaseService.CreateConversation(
+            new Conversation(Guid.Empty, "First", new List<Message>()));
+        await Task.Delay(10);
+
+        var id2 = await _databaseService.CreateConversation(
+            new Conversation(Guid.Empty, "Second", new List<Message>()));
+        await Task.Delay(10);
+
+        // Add message to first conversation to make it most recent
+        await _databaseService.InsertMessage(id1, new Message("Update"), null, null);
+
+        var conversations = await _databaseService.GetConversations();
+
+        Assert.Equal(id1, conversations.First().ConversationId);
+        Assert.Equal(id2, conversations.ElementAt(1).ConversationId);
+    }
+
+    [Fact]
+    public async Task CreateConversation_WithSpecialCharactersInTitle_ShouldSucceed()
+    {
+        const string title = "Test's \"Conversation\" with <special> & chars!";
+        var id = await _databaseService.CreateConversation(
+            new Conversation(Guid.Empty, title, new List<Message>()));
+
+        var conversations = await _databaseService.GetConversations();
+        var found = conversations.FirstOrDefault(c => c.ConversationId == id);
+
+        Assert.NotNull(found);
+        Assert.Equal(title, found.Title);
+    }
+
+    [Fact]
+    public async Task GetConversations_WithLargeDataset_ShouldComplete_Within1000ms()
+    {
+        for (var i = 0; i < 10_000; i++)
+        {
+            await _databaseService.CreateConversation(
+                new Conversation(Guid.Empty, $"Conv {i}", new List<Message>()));
+        }
+
+        var stopwatch = Stopwatch.StartNew();
+        var conversations = await _databaseService.GetConversations();
+        stopwatch.Stop();
+
+        Assert.NotEmpty(conversations);
+        Assert.True(stopwatch.ElapsedMilliseconds < 1000, $"Operation took too long: {stopwatch.ElapsedMilliseconds}ms");
+    }
+
+    [Fact]
+    public async Task DeleteConversation_ShouldCascadeDeleteMessages()
+    {
+        var id = await _databaseService.CreateConversation(
+            new Conversation(Guid.Empty, "Test", new List<Message>()));
+
+        await _databaseService.InsertMessage(id, new Message("Message 1"), null, null);
+        await _databaseService.InsertMessage(id, new Message("Message 2"), null, null);
+
+        // Delete conversation
+        var cmd = _connection.CreateCommand();
+        cmd.CommandText = "DELETE FROM conversations WHERE id = @id";
+        cmd.Parameters.AddWithValue("@id", id.ToString());
+        await cmd.ExecuteNonQueryAsync();
+
+        // Verify messages were cascade deleted
+        var msgCmd = _connection.CreateCommand();
+        msgCmd.CommandText = "SELECT COUNT(*) FROM messages WHERE conversation_id = @id";
+        msgCmd.Parameters.AddWithValue("@id", id.ToString());
+        var count = (long)(await msgCmd.ExecuteScalarAsync() ?? 0L);
+
+        Assert.Equal(0, count);
+    }
+
+    [Fact]
+    public async Task UpdateConversationTitle_WithValidId_ShouldReturnTrue()
+    {
+        var id = await _databaseService.CreateConversation(
+            new Conversation(Guid.Empty, "Original Title", new List<Message>()));
+
+        var updatedConversation = new Conversation(id, "Updated Title", new List<Message>());
+        var result = await _databaseService.UpdateConversationTitle(updatedConversation);
+
+        Assert.True(result);
+
+        var conversations = await _databaseService.GetConversations();
+        var found = conversations.FirstOrDefault(c => c.ConversationId == id);
+        Assert.NotNull(found);
+        Assert.Equal("Updated Title", found.Title);
+    }
+
+    [Fact]
+    public async Task UpdateConversationTitle_WithInvalidId_ShouldReturnFalse()
+    {
+        var nonExistentConversation = new Conversation(Guid.NewGuid(), "Title", new List<Message>());
+        var result = await _databaseService.UpdateConversationTitle(nonExistentConversation);
+
+        Assert.False(result);
+    }
+
+    // Message tests
+
+    [Fact]
+    public async Task InsertMessage_ShouldComplete_Within50ms()
+    {
+        // Ensure we have a conversation to add message to so foreign key constraint doesn't fail
+        var conversation = new Conversation(Guid.AllBitsSet, "Test Conversation", new List<Message>());
+        var conversationId = await _databaseService.CreateConversation(conversation);
+
+        var message = new Message("Test Message");
+        var stopwatch = Stopwatch.StartNew();
+        await _databaseService.InsertMessage(conversationId, message, null, null);
+        stopwatch.Stop();
+
+        Assert.True(stopwatch.ElapsedMilliseconds < 50, $"Operation took too long: {stopwatch.ElapsedMilliseconds}ms");
+    }
+
+    [Fact]
+    public async Task InsertMessage_WithFailedMessage_ShouldNotInsert()
+    {
+        var id = await _databaseService.CreateConversation(
+            new Conversation(Guid.Empty, "Test", new List<Message>()));
+
+        await _databaseService.InsertMessage(id, new FailedMessage(), null, null);
+
+        var messages = await _databaseService.GetMessagesForConversation(
+            new Conversation(id, "Test", new List<Message>()));
+
+        Assert.Empty(messages);
+    }
+
+    [Fact]
+    public async Task InsertMessage_ShouldHandle_ConcurrentWrites()
+    {
+        var conversationId = await _databaseService.CreateConversation(
+            new Conversation(Guid.Empty, "Concurrent Test", new List<Message>()));
+
+        var tasks = Enumerable.Range(0, 100)
+            .Select(i => _databaseService.InsertMessage(
+                conversationId,
+                new Message($"Message {i}"),
+                "llama3.2",
+                50.0));
+
+        // Should not throw exceptions
+        await Task.WhenAll(tasks);
+
+        var messages = await _databaseService.GetMessagesForConversation(
+            new Conversation(conversationId, "Test", new List<Message>()));
+        Assert.Equal(100, messages.Count);
+    }
+
+    [Fact]
+    public async Task InsertMessage_WithVeryLongContent_ShouldSucceed()
+    {
+        var id = await _databaseService.CreateConversation(
+            new Conversation(Guid.Empty, "Test", new List<Message>()));
+
+        var longContent = new string('a', 100_000);
+        await _databaseService.InsertMessage(id, new Message(longContent), null, null);
+
+        var messages = await _databaseService.GetMessagesForConversation(
+            new Conversation(id, "Test", new List<Message>()));
+
+        Assert.Single(messages);
+        Assert.Equal(longContent, messages[0].Content);
+    }
+
+    public void Dispose()
+    {
+        GC.SuppressFinalize(this);
+        _connection.Dispose();
+    }
+}

--- a/avallama.Tests/Services/OllamaServiceTests.cs
+++ b/avallama.Tests/Services/OllamaServiceTests.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Márk Csörgő and Martin Bartos
+// Licensed under the MIT License. See LICENSE file for details.
+
 using System;
 using System.Linq;
 using System.Collections.Generic;
@@ -13,7 +16,7 @@ using avallama.Models;
 using avallama.Services;
 using avallama.Tests.Extensions;
 using avallama.Tests.Fixtures;
-using avallama.Tests.Utilities;
+using avallama.Tests.TestUtilities;
 using Moq;
 using Moq.Protected;
 using Xunit;

--- a/avallama.Tests/TestUtilities/SynchronousAvaloniaDispatcher.cs
+++ b/avallama.Tests/TestUtilities/SynchronousAvaloniaDispatcher.cs
@@ -1,7 +1,10 @@
+// Copyright (c) Márk Csörgő and Martin Bartos
+// Licensed under the MIT License. See LICENSE file for details.
+
 using System;
 using avallama.Utilities;
 
-namespace avallama.Tests.Utilities;
+namespace avallama.Tests.TestUtilities;
 
 public class SynchronousAvaloniaDispatcher : IAvaloniaDispatcher
 {

--- a/avallama.Tests/Utilities/ObservableStackTests.cs
+++ b/avallama.Tests/Utilities/ObservableStackTests.cs
@@ -5,7 +5,7 @@ using System;
 using avallama.Utilities;
 using Xunit;
 
-namespace avallama.Tests;
+namespace avallama.Tests.Utilities;
 
 public class ObservableStackTests
 {

--- a/avallama.Tests/Utilities/RenderHelperTests.cs
+++ b/avallama.Tests/Utilities/RenderHelperTests.cs
@@ -4,7 +4,7 @@
 using avallama.Utilities;
 using Xunit;
 
-namespace avallama.Tests;
+namespace avallama.Tests.Utilities;
 
 public class RenderHelperTests
 {

--- a/avallama/App.axaml.cs
+++ b/avallama/App.axaml.cs
@@ -7,7 +7,6 @@ using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Data.Core.Plugins;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using avallama.Extensions;
 using Avalonia.Markup.Xaml;
@@ -77,7 +76,7 @@ public partial class App : Application
         _ollamaService = services.GetRequiredService<OllamaService>();
         _dialogService = services.GetRequiredService<DialogService>();
         _databaseInitService = services.GetRequiredService<DatabaseInitService>();
-        SharedDbConnection = Task.Run(() => _databaseInitService.GetOpenConnectionAsync()).GetAwaiter().GetResult();
+        SharedDbConnection = _databaseInitService.GetOpenConnectionAsync().GetAwaiter().GetResult();
 
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {

--- a/avallama/Services/DatabaseInitService.cs
+++ b/avallama/Services/DatabaseInitService.cs
@@ -1,5 +1,10 @@
+// Copyright (c) Márk Csörgő and Martin Bartos
+// Licensed under the MIT License. See LICENSE file for details.
+
 using System;
 using System.IO;
+using System.Security.Cryptography;
+using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Data.Sqlite;
 
@@ -14,10 +19,48 @@ public class DatabaseInitService : IDatabaseInitService
 {
     private readonly string _dbPath;
 
-    public DatabaseInitService()
+    // Canonical database schema, changing this will trigger a schema migration
+    // This is not able to handle complex migrations, which would probably facilitate an "API breaking" change anyway
+    private const string CanonicalSchema = """
+                                           CREATE TABLE IF NOT EXISTS conversations (
+                                           id TEXT PRIMARY KEY,
+                                           title TEXT NOT NULL,
+                                           created_at TEXT NOT NULL,
+                                           last_message_sent_at TEXT
+                                           );
+
+                                           CREATE TABLE IF NOT EXISTS messages (
+                                           id INTEGER PRIMARY KEY AUTOINCREMENT,
+                                           conversation_id TEXT NOT NULL,
+                                           role TEXT NOT NULL,
+                                           message TEXT NOT NULL,
+                                           timestamp TEXT NOT NULL,
+                                           model_name TEXT,
+                                           tokens_per_sec REAL,
+                                           FOREIGN KEY (conversation_id) REFERENCES conversations(id) ON DELETE CASCADE
+                                           );
+
+                                           CREATE INDEX IF NOT EXISTS idx_messages_convo_timestamp
+                                           ON messages (conversation_id, timestamp);
+
+                                           CREATE INDEX IF NOT EXISTS idx_conversations_last_msg
+                                           ON conversations (last_message_sent_at);
+                                           """;
+
+    public DatabaseInitService(bool? isTest = false)
     {
-        var exeDir = AppContext.BaseDirectory;
-        _dbPath = Path.Combine(exeDir, "avallama.db");
+        if (isTest.HasValue && isTest.Value)
+        {
+            _dbPath = ":memory:";
+            return;
+        }
+
+        var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+        var appDir = Path.Combine(appData, "avallama");
+        if (!Directory.Exists(appDir))
+            Directory.CreateDirectory(appDir);
+
+        _dbPath = Path.Combine(appDir, "avallama.db");
     }
 
     public async Task<SqliteConnection> GetOpenConnectionAsync()
@@ -29,76 +72,119 @@ public class DatabaseInitService : IDatabaseInitService
 
         if (isNew) await InitializeSchemaAsync(connection);
 
-        var isValid = await IsDatabaseValidAsync(connection);
-        var hasRequiredTables = await DoesTableExistAsync(connection, "conversations") &&
-                                await DoesTableExistAsync(connection, "messages");
+        var hasRequiredTables = await HasRequiredTablesAsync(connection);
 
-        if (!isValid || !hasRequiredTables)
+        if (!hasRequiredTables)
         {
-            // Ezt a hibat esetleg egy debug logba vagy valahogy mashogy meg lehetne jeleniteni
-            Console.WriteLine(
-                "Database file is present but either corrupted or missing required tables. Reinitializing.");
+            //TODO: LoggingService
+            Console.WriteLine("Database file is missing required tables. Reinitializing schema.");
             await InitializeSchemaAsync(connection);
+            return connection;
         }
+
+        var needsMigration = await NeedsMigrationAsync(connection);
+
+        if (!needsMigration) return connection;
+        Console.WriteLine("Database schema is outdated. Migrating...");
+        await MigrateSchemaAsync(connection);
+        Console.WriteLine("Database migration completed.");
 
         return connection;
     }
 
-    private async Task InitializeSchemaAsync(SqliteConnection conn)
+    private static async Task InitializeSchemaAsync(SqliteConnection conn)
     {
         var cmd = conn.CreateCommand();
-        cmd.CommandText = """
+        cmd.CommandText = $"""
                           PRAGMA foreign_keys = ON;
+                          PRAGMA journal_mode = WAL;
+                          PRAGMA synchronous = NORMAL;
+                          PRAGMA temp_store = MEMORY;
+                          PRAGMA cache_size = 32000;
 
-                          CREATE TABLE IF NOT EXISTS conversations (
-                          id TEXT PRIMARY KEY,
-                          title TEXT NOT NULL,
-                          created_at TEXT NOT NULL,
-                          last_message_sent_at TEXT
+                          CREATE TABLE IF NOT EXISTS schema_metadata (
+                          key TEXT PRIMARY KEY,
+                          value TEXT NOT NULL
                           );
 
-                          CREATE TABLE IF NOT EXISTS messages (
-                          id INTEGER PRIMARY KEY AUTOINCREMENT,
-                          conversation_id TEXT NOT NULL,
-                          role TEXT NOT NULL,
-                          message TEXT NOT NULL,
-                          timestamp TEXT NOT NULL,
-                          model_name TEXT,
-                          tokens_per_sec REAL,
-                          FOREIGN KEY (conversation_id) REFERENCES conversations(id) ON DELETE CASCADE
-                          );
-
-                          CREATE INDEX IF NOT EXISTS idx_messages_convo_timestamp
-                          ON messages (conversation_id, timestamp);
-
-                          CREATE INDEX IF NOT EXISTS idx_conversations_last_msg
-                          ON conversations (last_message_sent_at);
+                          {CanonicalSchema}
                           """;
         await cmd.ExecuteNonQueryAsync();
+        await StoreSchemaHashAsync(conn);
     }
 
-    private static async Task<bool> IsDatabaseValidAsync(SqliteConnection conn)
+    private static async Task<bool> NeedsMigrationAsync(SqliteConnection conn)
     {
+        await using var checkCmd = conn.CreateCommand();
+        checkCmd.CommandText = "SELECT name FROM sqlite_master WHERE type='table' AND name='schema_metadata'";
+        var exists = await checkCmd.ExecuteScalarAsync();
+        if (exists is null) return true;
+
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = "SELECT value FROM schema_metadata WHERE key = 'schema_hash' LIMIT 1";
+        var storedHash = await cmd.ExecuteScalarAsync() as string;
+        var currentHash = ComputeSchemaHash();
+        return storedHash != currentHash;
+    }
+
+    private static async Task MigrateSchemaAsync(SqliteConnection conn)
+    {
+        await using var transaction = await conn.BeginTransactionAsync();
         try
         {
             await using var cmd = conn.CreateCommand();
-            cmd.CommandText = "PRAGMA integrity_check;";
-            var result = (string?)await cmd.ExecuteScalarAsync();
+            cmd.CommandText = """
+                              CREATE TABLE IF NOT EXISTS schema_metadata (
+                              key TEXT PRIMARY KEY,
+                              value TEXT NOT NULL
+                              );
+                              """;
+            await cmd.ExecuteNonQueryAsync();
 
-            return result == "ok";
+            cmd.CommandText = CanonicalSchema;
+            await cmd.ExecuteNonQueryAsync();
+
+            await StoreSchemaHashAsync(conn);
+
+            await transaction.CommitAsync();
         }
-        catch (Exception)
+        catch (Exception ex)
         {
-            return false;
+            await transaction.RollbackAsync();
+            throw new InvalidOperationException("Schema migration failed.", ex);
         }
+
     }
 
-    public static async Task<bool> DoesTableExistAsync(SqliteConnection connection, string tableName)
+    private static async Task StoreSchemaHashAsync(SqliteConnection conn)
+    {
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = "INSERT OR REPLACE INTO schema_metadata (key, value) VALUES ('schema_hash', @Hash)";
+        cmd.Parameters.AddWithValue("@Hash", ComputeSchemaHash());
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    private static string ComputeSchemaHash()
+    {
+        var normalized = NormalizeSchema(CanonicalSchema);
+        var hashBytes = SHA512.HashData(Encoding.UTF8.GetBytes(normalized));
+        return Convert.ToHexString(hashBytes);
+    }
+
+    private static string NormalizeSchema(string schema)
+    {
+        return string.Join(" ", schema.Split([' ', '\r', '\n', '\t'],
+            StringSplitOptions.RemoveEmptyEntries));
+    }
+
+    private static async Task<bool> HasRequiredTablesAsync(SqliteConnection connection)
     {
         await using var cmd = connection.CreateCommand();
-        cmd.CommandText = "SELECT name FROM sqlite_master WHERE type='table' AND name=@name;";
-        cmd.Parameters.AddWithValue("@name", tableName);
-        var result = await cmd.ExecuteScalarAsync();
-        return result != null;
+        cmd.CommandText = """
+                          SELECT COUNT(*) FROM sqlite_master
+                          WHERE type='table' AND name IN ('conversations', 'messages');
+                          """;
+        var count = (long)(await cmd.ExecuteScalarAsync() ?? 0L);
+        return count == 2;
     }
 }

--- a/avallama/Services/DatabaseService.cs
+++ b/avallama/Services/DatabaseService.cs
@@ -1,14 +1,24 @@
+// Copyright (c) Márk Csörgő and Martin Bartos
+// Licensed under the MIT License. See LICENSE file for details.
+
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using avallama.Models;
 using avallama.Utilities;
 using Microsoft.Data.Sqlite;
 
 namespace avallama.Services;
+
+internal static class Roles
+{
+    public const string User = "user";
+    public const string Assistant = "assistant";
+}
 
 public interface IDatabaseService
 {
@@ -17,163 +27,192 @@ public interface IDatabaseService
     public Task<ObservableStack<Conversation>> GetConversations();
     public Task<bool> UpdateConversationTitle(Conversation conversation);
     public Task<ObservableCollection<Message>> GetMessagesForConversation(Conversation conversation);
-
 }
 
-public class DatabaseService : IDatabaseService
+public class DatabaseService : IDatabaseService, IDisposable
 {
-    private readonly string _connectionString;
-    private readonly DialogService _dialogService;
+    private readonly SqliteConnection _connection;
+    private readonly SemaphoreSlim _semaphore = new(1, 1);
 
-    public DatabaseService(DialogService dialogService)
+    public DatabaseService(SqliteConnection? testConnection = null)
     {
-        var exeDir = AppContext.BaseDirectory;
-        var dbPath = Path.Combine(exeDir, "avallama.db");
-        _connectionString = $"Data Source={dbPath}";
-        _dialogService = dialogService;
+        if (testConnection is not null)
+        {
+            _connection = testConnection;
+            _connection.Open();
+            return;
+        }
+
+        var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+        var appDir = Path.Combine(appData, "avallama");
+        if (!Directory.Exists(appDir))
+            Directory.CreateDirectory(appDir);
+
+        var dbPath = Path.Combine(appDir, "avallama.db");
+        var connectionString = $"Data Source={dbPath}";
+        _connection = new SqliteConnection(connectionString);
+        _connection.Open();
     }
 
     public async Task<Guid> CreateConversation(Conversation conversation)
     {
         var conversationId = Guid.NewGuid();
 
-        await using var connection = new SqliteConnection(_connectionString);
-        await connection.OpenAsync();
-        
-        var cmd = connection.CreateCommand();
-        cmd.CommandText = "INSERT INTO conversations (id, title, created_at, last_message_sent_at) VALUES (@Id, @Title, @CreatedAt, @LastMessageSentAt)";
-        cmd.Parameters.AddWithValue("@Id", conversationId);
-        cmd.Parameters.AddWithValue("@Title", conversation.Title);
-        cmd.Parameters.AddWithValue("@CreatedAt", DateTime.Now);
-        cmd.Parameters.AddWithValue("@LastMessageSentAt", DateTime.Now);
-
+        await _semaphore.WaitAsync();
         try
         {
-            await cmd.ExecuteNonQueryAsync();
+            await using var cmd = _connection.CreateCommand();
+            cmd.CommandText =
+                "INSERT INTO conversations (id, title, created_at, last_message_sent_at) VALUES (@Id, @Title, @CreatedAt, @LastMessageSentAt)";
+            cmd.Parameters.AddWithValue("@Id", conversationId);
+            cmd.Parameters.AddWithValue("@Title", conversation.Title);
+            cmd.Parameters.AddWithValue("@CreatedAt", DateTime.Now);
+            cmd.Parameters.AddWithValue("@LastMessageSentAt", DateTime.Now);
+
+            try
+            {
+                await cmd.ExecuteNonQueryAsync();
+            }
+            catch (Exception)
+            {
+                // TODO: InterruptService
+                throw;
+            }
         }
-        catch (Exception e)
+        finally
         {
-            _dialogService.ShowErrorDialog(LocalizationService.GetString("DATABASE_ERROR_OCCURRED") + e.Message);
-            throw;
+            _semaphore.Release();
         }
-        
+
         return conversationId;
     }
 
     public async Task InsertMessage(Guid conversationId, Message message, string? modelName, double? tokenPerSec)
     {
-        await using var connection = new SqliteConnection(_connectionString);
-        await connection.OpenAsync();
+        if (message is FailedMessage) return;
 
-        var cmd = connection.CreateCommand();
-        cmd.CommandText =
-            "INSERT INTO messages (conversation_id, role, message, timestamp, model_name, tokens_per_sec) VALUES (@ConversationId, @Role, @Message, @Timestamp, @ModelName, @TokenPerSec)";
-        cmd.Parameters.AddWithValue("@ConversationId", conversationId);
-        cmd.Parameters.AddWithValue("@Role", message is GeneratedMessage ? "assistant" : "user");
-        cmd.Parameters.AddWithValue("@Message", message.Content);
-        cmd.Parameters.AddWithValue("@Timestamp", DateTime.Now);
-        cmd.Parameters.AddWithValue("@ModelName", modelName ?? (object)DBNull.Value);
-        cmd.Parameters.AddWithValue("@TokenPerSec", tokenPerSec ?? (object)DBNull.Value);
-
-        if (message is not FailedMessage)
-        {
-            try
-            {
-                await cmd.ExecuteNonQueryAsync();
-                await UpdateLastMessageSent(conversationId);
-            }
-            catch (Exception e)
-            {
-                _dialogService.ShowErrorDialog(LocalizationService.GetString("DATABASE_ERROR_OCCURRED") + e.Message);
-                throw;
-                // TODO Implement logging service
-            }
-        }
-    }
-
-    private async Task UpdateLastMessageSent(Guid conversationId)
-    {
-        await using var connection = new SqliteConnection(_connectionString);
-        await connection.OpenAsync();
-        var cmd = connection.CreateCommand();
-        cmd.CommandText = "UPDATE conversations SET last_message_sent_at = @LastMessageSentAt WHERE id = @ConversationId";
-        cmd.Parameters.AddWithValue("@LastMessageSentAt", DateTime.Now);
-        cmd.Parameters.AddWithValue("@ConversationId", conversationId);
+        await _semaphore.WaitAsync();
         try
         {
-            await cmd.ExecuteNonQueryAsync();
+            await using var transaction = await _connection.BeginTransactionAsync();
+            var now = DateTime.Now;
+
+            try
+            {
+                await using var insertCmd = _connection.CreateCommand();
+                // Create transaction to ensure both inserts succeed or fail together
+                insertCmd.Transaction = (SqliteTransaction)transaction;
+
+                // Insert message
+                insertCmd.CommandText =
+                    "INSERT INTO messages (conversation_id, role, message, timestamp, model_name, tokens_per_sec) VALUES (@ConversationId, @Role, @Message, @Timestamp, @ModelName, @TokenPerSec)";
+                insertCmd.Parameters.AddWithValue("@ConversationId", conversationId);
+                insertCmd.Parameters.AddWithValue("@Role", message is GeneratedMessage ? "assistant" : "user");
+                insertCmd.Parameters.AddWithValue("@Message", message.Content);
+                insertCmd.Parameters.AddWithValue("@Timestamp", now);
+                insertCmd.Parameters.AddWithValue("@ModelName", modelName ?? (object)DBNull.Value);
+                insertCmd.Parameters.AddWithValue("@TokenPerSec", tokenPerSec ?? (object)DBNull.Value);
+                await insertCmd.ExecuteNonQueryAsync();
+
+                // Update conversation's last_message_sent_at
+                await using var updateCmd = _connection.CreateCommand();
+                updateCmd.Transaction = (SqliteTransaction)transaction;
+                updateCmd.CommandText =
+                    "UPDATE conversations SET last_message_sent_at = @LastMessageSentAt WHERE id = @ConversationId";
+                updateCmd.Parameters.AddWithValue("@LastMessageSentAt", now);
+                updateCmd.Parameters.AddWithValue("@ConversationId", conversationId);
+                await updateCmd.ExecuteNonQueryAsync();
+
+                // Commit transaction
+                await transaction.CommitAsync();
+            }
+            catch (Exception)
+            {
+                await transaction.RollbackAsync();
+                // TODO: InterruptService
+                throw;
+            }
         }
-        catch (Exception e)
+        finally
         {
-            _dialogService.ShowErrorDialog(LocalizationService.GetString("DATABASE_ERROR_OCCURRED") + e.Message);
-            throw;
+            _semaphore.Release();
         }
     }
 
     public async Task<ObservableStack<Conversation>> GetConversations()
     {
-        await using var connection = new SqliteConnection(_connectionString);
-        await connection.OpenAsync();
-        var cmd = connection.CreateCommand();
-        cmd.CommandText = "SELECT * FROM conversations ORDER BY last_message_sent_at DESC";
-        await using var reader = await cmd.ExecuteReaderAsync();
-        var conversations = new ObservableStack<Conversation>();
-        var conversationIds = new List<Guid>();
-        if (!reader.HasRows) return conversations;
-
+        ObservableStack<Conversation> conversations;
+        await _semaphore.WaitAsync();
         try
         {
-            while (await reader.ReadAsync())
+            await using var cmd = _connection.CreateCommand();
+            cmd.CommandText = "SELECT * FROM conversations ORDER BY last_message_sent_at DESC";
+            await using var reader = await cmd.ExecuteReaderAsync();
+            conversations = [];
+            var conversationIds = new List<Guid>();
+            if (!reader.HasRows) return conversations;
+
+            try
             {
-                var id = Guid.Parse((string)reader["id"]);
-                var conversation = new Conversation(
-                    Guid.Parse((string)reader["id"]),
-                    (string)reader["title"],
-                    new List<Message>()
-                );
-                conversations.Add(conversation);
-                conversationIds.Add(id);
+                while (await reader.ReadAsync())
+                {
+                    var id = Guid.Parse((string)reader["id"]);
+                    var conversation = new Conversation(
+                        Guid.Parse((string)reader["id"]),
+                        (string)reader["title"],
+                        new List<Message>()
+                    );
+                    conversations.Add(conversation);
+                    conversationIds.Add(id);
+                }
             }
+            catch (Exception)
+            {
+                // TODO: InterruptService
+                throw;
+            }
+
+            var lastModels = await GetLastModelsForConversationsAsync(conversationIds);
+
+            foreach (var conv in conversations)
+            {
+                conv.Model =
+                    lastModels.GetValueOrDefault(conv.ConversationId,
+                        "llama3.2:2b"); // this default could be set in settings?
+            }
+
         }
-        catch (Exception e)
+        finally
         {
-            _dialogService.ShowErrorDialog(LocalizationService.GetString("DATABASE_ERROR_OCCURRED") + e.Message);
-            throw;
+            _semaphore.Release();
         }
-        
-        var lastModels = await GetLastModelsForConversationsAsync(conversationIds);
-        
-        foreach (var conv in conversations)
-        {
-            conv.Model = lastModels.GetValueOrDefault(conv.ConversationId, "llama3.2:2b"); // this default could be set in settings?
-        }
-        
+
         return conversations;
     }
 
     private async Task<Dictionary<Guid, string>> GetLastModelsForConversationsAsync(IEnumerable<Guid> conversationIds)
     {
+        // Semaphore is already held by caller
+
         var lastModels = new Dictionary<Guid, string>();
 
         var enumerable = conversationIds as Guid[] ?? conversationIds.ToArray();
         if (enumerable.Length == 0)
             return lastModels;
 
-        await using var connection = new SqliteConnection(_connectionString);
-        await connection.OpenAsync();
-
         var idsParam = string.Join(",", enumerable.Select((_, i) => $"@id{i}"));
-        await using var cmd = connection.CreateCommand();
+        await using var cmd = _connection.CreateCommand();
         cmd.CommandText = $"""
-                                   SELECT conversation_id, model_name
+                               SELECT conversation_id, model_name
+                               FROM (
+                                   SELECT conversation_id, model_name,
+                                          ROW_NUMBER() OVER (PARTITION BY conversation_id ORDER BY timestamp DESC) AS rn
                                    FROM messages
                                    WHERE conversation_id IN ({idsParam})
-                                   AND timestamp = (
-                                       SELECT MAX(timestamp) 
-                                       FROM messages m2 
-                                       WHERE m2.conversation_id = messages.conversation_id
-                                   )
+                               )
+                               WHERE rn = 1
                            """;
+
 
         var index = 0;
         foreach (var id in enumerable)
@@ -189,10 +228,9 @@ public class DatabaseService : IDatabaseService
                 lastModels[convId] = model;
             }
         }
-        catch (Exception e)
+        catch (Exception)
         {
-            _dialogService.ShowErrorDialog(
-                LocalizationService.GetString("DATABASE_ERROR_OCCURRED") + e.Message);
+            // TODO: InterruptService
             throw;
         }
 
@@ -202,56 +240,76 @@ public class DatabaseService : IDatabaseService
 
     public async Task<bool> UpdateConversationTitle(Conversation conversation)
     {
-        await using var connection = new SqliteConnection(_connectionString);
-        await connection.OpenAsync();
-        var cmd = connection.CreateCommand();
-        cmd.CommandText = "UPDATE conversations SET title = @title WHERE id = @ConversationId";
-        cmd.Parameters.AddWithValue("@title", conversation.Title);
-        cmd.Parameters.AddWithValue("@ConversationId", conversation.ConversationId.ToString().ToUpper());
+        await _semaphore.WaitAsync();
         try
         {
-            var res = await cmd.ExecuteNonQueryAsync();
-            return res > 0;
+            await using var cmd = _connection.CreateCommand();
+            cmd.CommandText = "UPDATE conversations SET title = @title WHERE id = @ConversationId";
+            cmd.Parameters.AddWithValue("@title", conversation.Title);
+            cmd.Parameters.AddWithValue("@ConversationId", conversation.ConversationId);
+            try
+            {
+                var res = await cmd.ExecuteNonQueryAsync();
+                return res > 0;
+            }
+            catch (Exception)
+            {
+                // TODO: InterruptService
+                throw;
+            }
         }
-        catch (Exception e)
+        finally
         {
-            _dialogService.ShowErrorDialog(LocalizationService.GetString("DATABASE_ERROR_OCCURRED") + e.Message);
-            throw;
+            _semaphore.Release();
         }
     }
 
     public async Task<ObservableCollection<Message>> GetMessagesForConversation(Conversation conversation)
     {
-        var messages = new ObservableCollection<Message>();
-        await using var connection = new SqliteConnection(_connectionString);
-        await connection.OpenAsync();
-        var cmd = connection.CreateCommand();
-        cmd.CommandText = "SELECT * FROM messages WHERE conversation_id = @ConversationId ORDER BY timestamp";
-        cmd.Parameters.AddWithValue("@ConversationId", conversation.ConversationId.ToString().ToUpper());
-        await using var reader = await cmd.ExecuteReaderAsync();
+        ObservableCollection<Message> messages;
+        await _semaphore.WaitAsync();
         try
         {
-            while (await reader.ReadAsync())
+            messages = [];
+            await using var cmd = _connection.CreateCommand();
+            cmd.CommandText = "SELECT * FROM messages WHERE conversation_id = @ConversationId ORDER BY timestamp";
+            cmd.Parameters.AddWithValue("@ConversationId", conversation.ConversationId);
+            await using var reader = await cmd.ExecuteReaderAsync();
+            try
             {
-                Message message;
-                switch (reader["role"].ToString())
+                while (await reader.ReadAsync())
                 {
-                    case "user":
-                        message = new Message(reader["message"].ToString()!);
-                        messages.Add(message);
-                        break;
-                    case "assistant":
-                        message = new GeneratedMessage(reader["message"].ToString()!, (double)reader["tokens_per_sec"]);
-                        messages.Add(message);
-                        break;
+                    var role = reader["role"].ToString();
+                    var content = reader["message"].ToString()!;
+
+                    var message = role switch
+                    {
+                        Roles.User => new Message(content),
+                        Roles.Assistant => new GeneratedMessage(content, (double)reader["tokens_per_sec"]),
+                        _ => throw new InvalidOperationException($"Unknown role: {role}")
+                    };
+
+                    messages.Add(message);
                 }
             }
+            catch (Exception)
+            {
+                // TODO: InterruptService
+                throw;
+            }
         }
-        catch (Exception e)
+        finally
         {
-            _dialogService.ShowErrorDialog(LocalizationService.GetString("DATABASE_ERROR_OCCURRED") + e.Message);
-            throw;
+            _semaphore.Release();
         }
+
         return messages;
+    }
+
+    public void Dispose()
+    {
+        _semaphore.Dispose();
+        _connection.Dispose();
+        GC.SuppressFinalize(this);
     }
 }

--- a/avallama/Views/HomeView.axaml.cs
+++ b/avallama/Views/HomeView.axaml.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Márk Csörgő and Martin Bartos
 // Licensed under the MIT License. See LICENSE file for details.
 
-using System;
 using System.Linq;
 using System.Runtime.InteropServices;
 using avallama.Services;
@@ -49,6 +48,8 @@ public partial class HomeView : UserControl
 
     // megnézi hogy milyen állapotban van az ablak és a sidebar
     // majd eszerint beállítja a marginjukat, hogy macOS-en az ablakkezelő gombok használhatóak legyenek
+
+    // ReSharper disable once InconsistentNaming
     private void SetMacOSMargin()
     {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) return;


### PR DESCRIPTION
Fixes https://github.com/4foureyes/avallamaplanning/issues/84
Closes https://github.com/4foureyes/avallamaplanning/issues/86

### Changes 
For https://github.com/4foureyes/avallamaplanning/issues/84:
- `ConfigurationService` now saves configurations to a json file that is saved to the `ApplicationData` special folder
- The database services now save the database to the `ApplicationData` special folder
- I've manually tested this on WSL and bare metal Debian 13 and a Arch podman container and everything worked as expected

For https://github.com/4foureyes/avallamaplanning/issues/86:
- Optimized the database service queries in several areas
- Added PRAGMAS:
    - `journal_mode =  WAL`: this enables Write-Ahead Logging which drastically improves write performance and makes transactions atomic even during a crash scenario
    - `synchronous = normal`: enables normal synchronous behavior
    - `temp_store = memory`: stores temporary tables and indexes in RAM
    - `cache_size = 32000`: sets database page cache to 32K pages (~125MB RAM)
- Added a database migration system which detects changes in the schema by comparing hashes, and executes the updated schema definition if a change is detected
- Removed unnecessary schema validation at app startup as it costed ~200ms
- Added a semaphore to `DatabaseService` to prevent multiple read/writes concurrently if that situation were to ever occur

Miscellaneous:
- Rearranged the Tests project to include tests in their respective folder, and updated the namespaces accordingly
- Disabled an Inconsistent Naming warning for the `SetMacOSMargin()` method

**Note:** These are breaking changes, so your configuration files and database will be gone when testing/merged upstream