### PR TITLE
Declare package dependencies in Linux build scripts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,7 @@ jobs:
     steps:
       - name: Install base build tools and .NET
         run: |
-          pacman -Sy --noconfirm base-devel git curl unzip icu dotnet-sdk dotnet-runtime
+          pacman -Sy --noconfirm base-devel git curl unzip icu dotnet-sdk dotnet-runtime fontconfig freetype2 libx11 libxrender libxcb mesa libpng zlib
           dotnet --version
 
       - name: Checkout source

--- a/scripts/package-arch.sh
+++ b/scripts/package-arch.sh
@@ -44,6 +44,7 @@ arch=('x86_64')
 pkgdesc="User-friendly GUI for Ollama"
 url="https://www.github.com/4foureyes/avallama"
 license=('MIT')
+depends=('icu' 'fontconfig' 'freetype2' 'libx11' 'libxrender' 'libxcb' 'mesa' 'libpng' 'zlib')
 source=()
 sha256sums=()
 options=(!debug !strip)

--- a/scripts/package-debian.sh
+++ b/scripts/package-debian.sh
@@ -9,7 +9,7 @@ fi
 
 PROJECT="avallama/avallama.csproj"
 
-dotnet publish ${PROJECT} \
+dotnet publish "${PROJECT}" \
   --verbosity quiet \
   --nologo \
   --configuration Release \
@@ -18,49 +18,153 @@ dotnet publish ${PROJECT} \
   --output "./out/linux-x64"
 
 rm -rf staging_folder
-mkdir staging_folder
+mkdir -p staging_folder/DEBIAN
+mkdir -p staging_folder/usr/{bin,lib/avallama,share/{applications,pixmaps,icons/hicolor,doc/avallama}}
 
-mkdir ./staging_folder/DEBIAN
 cat > ./staging_folder/DEBIAN/control <<EOF
 Package: avallama
 Version: ${VERSION}
 Section: devel
 Priority: optional
 Architecture: amd64
-Description: User-friendly GUI for Ollama
-Maintainer: Márk Csörgő, Martin Bartos - 4foureyes
+Depends: libc6 (>= 2.34), libicu76, libfontconfig1, libfreetype6, libx11-6, libxrender1, libxcb1, libgl1, libpng16-16
+Maintainer: Márk Csörgő <mcsorgo@proton.me>
 Homepage: https://github.com/4foureyes/avallama
-Copyright: 2025 Márk Csörgő, Martin Bartos
+Description: User-friendly GUI for Ollama
+ A cross-platform Avalonia-based GUI for running local AI models through
+ Ollama. Designed for simplicity and performance.
+EOF
+
+cat > ./staging_folder/usr/share/doc/avallama/copyright <<EOF
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: Avallama
+Source: https://github.com/4foureyes/avallama
+
+Files: avallama avallama.dll avallama.pdb avallama.deps.json avallama.runtimeconfig.json Assets/* hu/*
+Copyright: Márk Csörgő <mcsorgo@proton.me>
+           Martin Bartos <bmartin217@proton.me>
+License: MIT
+
+Files: Avalonia.*.dll
+Copyright: AvaloniaUI OÜ
+License: MIT
+
+Files: CommunityToolkit.Mvvm.dll
+Copyright: .NET Foundation and Contributors
+License: MIT
+
+Files: HtmlAgilityPack.dll
+Copyright: ZZZ Projects Inc.
+License: MIT
+
+Files: Svg.Controls.Avalonia.dll
+       Svg.Custom.dll
+       Svg.Model.dll
+Copyright: Wiesław Šoltés
+License: MIT
+
+Files: SkiaSharp.dll
+       HarfBuzzSharp.dll
+       ShimSkiaSharp.dll
+       libSkiaSharp.so
+       libHarfBuzzSharp.so
+Copyright: Xamarin, Inc.
+           Microsoft Corporation
+License: MIT
+
+Files: ExCSS.dll
+Copyright: Tyler Brinks
+License: MIT
+
+Files: SQLitePCLRaw.*.dll
+       libe_sqlite3.so
+Copyright: Eric Sink
+License: Apache-2.0
+
+Files: System.*.dll
+       Microsoft.*.dll
+       mscorlib.dll
+       netstandard.dll
+       libcoreclr*.so
+       libclr*.so
+       libhostfxr.so
+       libhostpolicy.so
+       libmscordaccore.so
+       libmscordbi.so
+       libSystem.*.so
+       createdump
+Copyright: Microsoft Corporation and .NET Foundation
+License: MIT
+
+Files: Tmds.DBus.Protocol.dll
+Copyright: Alp Toker <alp@toker.com>
+           Tom Deseyn <tom.deseyn@gmail.com>
+License: MIT
+
+Files: MicroCom.Runtime.dll
+Copyright: Nikita Tsukanov
+License: MIT
+
+License: MIT
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ .
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+ .
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+
+License: Apache-2.0
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ .
+     http://www.apache.org/licenses/LICENSE-2.0
+ .
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ .
+ On Debian systems, the full text of the Apache License version 2.0
+ can be found in the file '/usr/share/common-licenses/Apache-2.0'.
 EOF
 
 # Starter script
-mkdir ./staging_folder/usr
-mkdir ./staging_folder/usr/bin
 cp scripts/debian/avallama.sh ./staging_folder/usr/bin/avallama
-chmod +x ./staging_folder/usr/bin/avallama # set executable permissions to starter script
 
-# Other files
-mkdir ./staging_folder/usr/lib
-mkdir ./staging_folder/usr/lib/avallama
-cp -f -a ./out/linux-x64/. ./staging_folder/usr/lib/avallama/ # copies all files from publish dir
-chmod -R a+rX ./staging_folder/usr/lib/avallama/ # set read permissions to all files
-chmod +x ./staging_folder/usr/lib/avallama/avallama # set executable permissions to main executable
+# Application files
+cp -a ./out/linux-x64/. ./staging_folder/usr/lib/avallama/
 
-# Desktop shortcut
-mkdir ./staging_folder/usr/share
-mkdir ./staging_folder/usr/share/applications
+# Fix permissions: no world-writable or executable .dll/.so
+find ./staging_folder/usr/lib/avallama -type d -exec chmod 755 {} +
+find ./staging_folder/usr/lib/avallama -type f -exec chmod 644 {} +
+
+# Strip unneeded symbols from binaries
+find ./staging_folder/usr/lib/avallama -type f -name "*.so" -exec strip --strip-unneeded {} + || true
+strip --strip-unneeded ./staging_folder/usr/lib/avallama/avallama || true
+
+# Desktop entry and icons
 cp scripts/debian/Avallama.desktop ./staging_folder/usr/share/applications/
-
-# Desktop icon
-# A 1024px x 1024px PNG, like VS Code uses for its icon
-mkdir ./staging_folder/usr/share/pixmaps
 cp scripts/debian/pixmaps/avallama.png ./staging_folder/usr/share/pixmaps/
-
-# Hicolor icons
-mkdir ./staging_folder/usr/share/icons
-mkdir ./staging_folder/usr/share/icons/hicolor
 cp -a scripts/debian/icons/hicolor/. ./staging_folder/usr/share/icons/hicolor/
 
-# Make .deb file
-dpkg-deb --root-owner-group --build ./staging_folder/ ./avallama_"${VERSION}"_amd64.deb
+# Normalize permissions
+find ./staging_folder -type d -exec chmod 755 {} +
+find ./staging_folder -type f -exec chmod 644 {} +
+chmod 755 ./staging_folder/usr/bin/avallama
+chmod 755 ./staging_folder/usr/lib/avallama/avallama
 
+# Build .deb package
+dpkg-deb --root-owner-group --build ./staging_folder ./avallama_"${VERSION}"_amd64.deb


### PR DESCRIPTION
Closes https://github.com/4foureyes/avallamaplanning/issues/87

Changes:
- Declared package dependencies in both the Debian and Arch Linux build scripts
- Refactored the Debian build script to be more compliant with standards

I tested these changes in minimal podman containers and was able to install the application and run it without having to manually install the dependencies.

I also ran lintian to validate the Debian package and the following problems remain unsolved, which should be addressed in a future PR:
```
E: avallama: embedded-library expat [usr/lib/avallama/libSkiaSharp.so]
E: avallama: embedded-library freetype [usr/lib/avallama/libSkiaSharp.so]
E: avallama: embedded-library libjpeg [usr/lib/avallama/libSkiaSharp.so]
E: avallama: embedded-library libpng [usr/lib/avallama/libSkiaSharp.so]
```
- `libSkiaSharp.so` is providing system libraries expat, freetype, libjpeg and libpng precompiled within the binary.

```
E: avallama: embedded-library zlib [usr/lib/avallama/libSystem.IO.Compression.Native.so]
```
- `libSystem.IO.Compression.Native.so` is providing zlib precompiled within the binary

```
E: avallama: no-changelog usr/share/doc/avallama/changelog.gz (native package)
```
- A changelog file needs to be created

```
W: avallama: no-manual-page [usr/bin/avallama]
```
- A manual page needs to be created