### PR TITLE
Add support for caching online model data

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -52,6 +52,8 @@ jobs:
           --no-build
           --collect:"XPlat Code Coverage"
           --logger "trx;LogFileName=test-results.trx"
+          --logger "console;verbosity=detailed"
+          -v d
 
       - name: Upload test results
         if: always()

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 <h1 align="center">Avallama</h1>
 
 <p align="center">
-  <a href="https://github.com/eyeonspringfield/avallama/actions/workflows/pr.yml">
-    <img alt="Build" src="https://github.com/eyeonspringfield/avallama/actions/workflows/pr.yml/badge.svg?branch=main">
+  <a href="https://github.com/4foureyes/avallama/actions/workflows/pr.yml">
+    <img alt="Build" src="https://github.com/4foureyes/avallama/actions/workflows/pr.yml/badge.svg?branch=main">
   </a>
-  <a href="https://codecov.io/gh/eyeonspringfield/avallama">
-    <img alt="Coverage" src="https://codecov.io/gh/eyeonspringfield/avallama/branch/main/graph/badge.svg">
+  <a href="https://codecov.io/gh/4foureyes/avallama">
+    <img alt="Coverage" src="https://codecov.io/gh/4foureyes/avallama/branch/main/graph/badge.svg">
   </a>
 </p>
 

--- a/avallama.Tests/Fixtures/TestServicesFixture.cs
+++ b/avallama.Tests/Fixtures/TestServicesFixture.cs
@@ -9,6 +9,6 @@ public class TestServicesFixture
     public Mock<IOllamaService> OllamaMock { get; } = new();
     public Mock<IDialogService> DialogMock { get; } = new();
     public Mock<IConfigurationService> ConfigMock { get; } = new();
-    public Mock<IDatabaseService> DbMock { get; } = new();
+    public Mock<IConversationService> DbMock { get; } = new();
     public Mock<IMessenger> MessengerMock { get; } = new();
 }

--- a/avallama.Tests/Services/ConversationsServiceTests.cs
+++ b/avallama.Tests/Services/ConversationsServiceTests.cs
@@ -14,12 +14,13 @@ using Xunit;
 
 namespace avallama.Tests.Services;
 
-public class DatabaseServiceTests : IDisposable
+[Collection("Database Tests")]
+public class ConversationServiceTests : IDisposable
 {
     private readonly SqliteConnection _connection;
-    private readonly DatabaseService _databaseService;
+    private readonly ConversationService _conversationService;
 
-    public DatabaseServiceTests()
+    public ConversationServiceTests()
     {
 
         _connection = new SqliteConnection("Data Source=:memory:");
@@ -27,7 +28,7 @@ public class DatabaseServiceTests : IDisposable
 
         InitializeTestSchema(_connection);
 
-        _databaseService = new DatabaseService(_connection);
+        _conversationService = new ConversationService(_connection);
     }
 
     private static void InitializeTestSchema(SqliteConnection connection)
@@ -74,7 +75,7 @@ public class DatabaseServiceTests : IDisposable
     {
         var conversation = new Conversation(Guid.AllBitsSet, "Test Conversation", new List<Message>());
         var stopwatch = Stopwatch.StartNew();
-        await _databaseService.CreateConversation(conversation);
+        await _conversationService.CreateConversation(conversation);
         stopwatch.Stop();
 
         Assert.True(stopwatch.ElapsedMilliseconds < 100, $"Operation took too long: {stopwatch.ElapsedMilliseconds}ms");
@@ -83,16 +84,16 @@ public class DatabaseServiceTests : IDisposable
     [Fact]
     public async Task GetMessagesForConversation_ShouldReturnMessagesInOrder()
     {
-        var id = await _databaseService.CreateConversation(
+        var id = await _conversationService.CreateConversation(
             new Conversation(Guid.Empty, "Test", new List<Message>()));
 
-        await _databaseService.InsertMessage(id, new Message("First"), null, null);
+        await _conversationService.InsertMessage(id, new Message("First"), null, null);
         await Task.Delay(10);
-        await _databaseService.InsertMessage(id, new GeneratedMessage("Second", 50.0), "model", 50.0);
+        await _conversationService.InsertMessage(id, new GeneratedMessage("Second", 50.0), "model", 50.0);
         await Task.Delay(10);
-        await _databaseService.InsertMessage(id, new Message("Third"), null, null);
+        await _conversationService.InsertMessage(id, new Message("Third"), null, null);
 
-        var messages = await _databaseService.GetMessagesForConversation(
+        var messages = await _conversationService.GetMessagesForConversation(
             new Conversation(id, "Test", new List<Message>()));
 
         Assert.Equal(3, messages.Count);
@@ -105,10 +106,10 @@ public class DatabaseServiceTests : IDisposable
     [Fact]
     public async Task GetMessagesForConversation_WithNoMessages_ShouldReturnEmpty()
     {
-        var id = await _databaseService.CreateConversation(
+        var id = await _conversationService.CreateConversation(
             new Conversation(Guid.Empty, "Empty", new List<Message>()));
 
-        var messages = await _databaseService.GetMessagesForConversation(
+        var messages = await _conversationService.GetMessagesForConversation(
             new Conversation(id, "Empty", new List<Message>()));
 
         Assert.Empty(messages);
@@ -117,18 +118,18 @@ public class DatabaseServiceTests : IDisposable
     [Fact]
     public async Task GetConversations_ShouldOrderByLastMessage()
     {
-        var id1 = await _databaseService.CreateConversation(
+        var id1 = await _conversationService.CreateConversation(
             new Conversation(Guid.Empty, "First", new List<Message>()));
         await Task.Delay(10);
 
-        var id2 = await _databaseService.CreateConversation(
+        var id2 = await _conversationService.CreateConversation(
             new Conversation(Guid.Empty, "Second", new List<Message>()));
         await Task.Delay(10);
 
         // Add message to first conversation to make it most recent
-        await _databaseService.InsertMessage(id1, new Message("Update"), null, null);
+        await _conversationService.InsertMessage(id1, new Message("Update"), null, null);
 
-        var conversations = await _databaseService.GetConversations();
+        var conversations = await _conversationService.GetConversations();
 
         Assert.Equal(id1, conversations.First().ConversationId);
         Assert.Equal(id2, conversations.ElementAt(1).ConversationId);
@@ -138,10 +139,10 @@ public class DatabaseServiceTests : IDisposable
     public async Task CreateConversation_WithSpecialCharactersInTitle_ShouldSucceed()
     {
         const string title = "Test's \"Conversation\" with <special> & chars!";
-        var id = await _databaseService.CreateConversation(
+        var id = await _conversationService.CreateConversation(
             new Conversation(Guid.Empty, title, new List<Message>()));
 
-        var conversations = await _databaseService.GetConversations();
+        var conversations = await _conversationService.GetConversations();
         var found = conversations.FirstOrDefault(c => c.ConversationId == id);
 
         Assert.NotNull(found);
@@ -153,12 +154,12 @@ public class DatabaseServiceTests : IDisposable
     {
         for (var i = 0; i < 10_000; i++)
         {
-            await _databaseService.CreateConversation(
+            await _conversationService.CreateConversation(
                 new Conversation(Guid.Empty, $"Conv {i}", new List<Message>()));
         }
 
         var stopwatch = Stopwatch.StartNew();
-        var conversations = await _databaseService.GetConversations();
+        var conversations = await _conversationService.GetConversations();
         stopwatch.Stop();
 
         Assert.NotEmpty(conversations);
@@ -168,11 +169,11 @@ public class DatabaseServiceTests : IDisposable
     [Fact]
     public async Task DeleteConversation_ShouldCascadeDeleteMessages()
     {
-        var id = await _databaseService.CreateConversation(
+        var id = await _conversationService.CreateConversation(
             new Conversation(Guid.Empty, "Test", new List<Message>()));
 
-        await _databaseService.InsertMessage(id, new Message("Message 1"), null, null);
-        await _databaseService.InsertMessage(id, new Message("Message 2"), null, null);
+        await _conversationService.InsertMessage(id, new Message("Message 1"), null, null);
+        await _conversationService.InsertMessage(id, new Message("Message 2"), null, null);
 
         // Delete conversation
         var cmd = _connection.CreateCommand();
@@ -192,15 +193,15 @@ public class DatabaseServiceTests : IDisposable
     [Fact]
     public async Task UpdateConversationTitle_WithValidId_ShouldReturnTrue()
     {
-        var id = await _databaseService.CreateConversation(
+        var id = await _conversationService.CreateConversation(
             new Conversation(Guid.Empty, "Original Title", new List<Message>()));
 
         var updatedConversation = new Conversation(id, "Updated Title", new List<Message>());
-        var result = await _databaseService.UpdateConversationTitle(updatedConversation);
+        var result = await _conversationService.UpdateConversationTitle(updatedConversation);
 
         Assert.True(result);
 
-        var conversations = await _databaseService.GetConversations();
+        var conversations = await _conversationService.GetConversations();
         var found = conversations.FirstOrDefault(c => c.ConversationId == id);
         Assert.NotNull(found);
         Assert.Equal("Updated Title", found.Title);
@@ -210,7 +211,7 @@ public class DatabaseServiceTests : IDisposable
     public async Task UpdateConversationTitle_WithInvalidId_ShouldReturnFalse()
     {
         var nonExistentConversation = new Conversation(Guid.NewGuid(), "Title", new List<Message>());
-        var result = await _databaseService.UpdateConversationTitle(nonExistentConversation);
+        var result = await _conversationService.UpdateConversationTitle(nonExistentConversation);
 
         Assert.False(result);
     }
@@ -222,11 +223,11 @@ public class DatabaseServiceTests : IDisposable
     {
         // Ensure we have a conversation to add message to so foreign key constraint doesn't fail
         var conversation = new Conversation(Guid.AllBitsSet, "Test Conversation", new List<Message>());
-        var conversationId = await _databaseService.CreateConversation(conversation);
+        var conversationId = await _conversationService.CreateConversation(conversation);
 
         var message = new Message("Test Message");
         var stopwatch = Stopwatch.StartNew();
-        await _databaseService.InsertMessage(conversationId, message, null, null);
+        await _conversationService.InsertMessage(conversationId, message, null, null);
         stopwatch.Stop();
 
         Assert.True(stopwatch.ElapsedMilliseconds < 50, $"Operation took too long: {stopwatch.ElapsedMilliseconds}ms");
@@ -235,12 +236,12 @@ public class DatabaseServiceTests : IDisposable
     [Fact]
     public async Task InsertMessage_WithFailedMessage_ShouldNotInsert()
     {
-        var id = await _databaseService.CreateConversation(
+        var id = await _conversationService.CreateConversation(
             new Conversation(Guid.Empty, "Test", new List<Message>()));
 
-        await _databaseService.InsertMessage(id, new FailedMessage(), null, null);
+        await _conversationService.InsertMessage(id, new FailedMessage(), null, null);
 
-        var messages = await _databaseService.GetMessagesForConversation(
+        var messages = await _conversationService.GetMessagesForConversation(
             new Conversation(id, "Test", new List<Message>()));
 
         Assert.Empty(messages);
@@ -249,11 +250,11 @@ public class DatabaseServiceTests : IDisposable
     [Fact]
     public async Task InsertMessage_ShouldHandle_ConcurrentWrites()
     {
-        var conversationId = await _databaseService.CreateConversation(
+        var conversationId = await _conversationService.CreateConversation(
             new Conversation(Guid.Empty, "Concurrent Test", new List<Message>()));
 
         var tasks = Enumerable.Range(0, 100)
-            .Select(i => _databaseService.InsertMessage(
+            .Select(i => _conversationService.InsertMessage(
                 conversationId,
                 new Message($"Message {i}"),
                 "llama3.2",
@@ -262,7 +263,7 @@ public class DatabaseServiceTests : IDisposable
         // Should not throw exceptions
         await Task.WhenAll(tasks);
 
-        var messages = await _databaseService.GetMessagesForConversation(
+        var messages = await _conversationService.GetMessagesForConversation(
             new Conversation(conversationId, "Test", new List<Message>()));
         Assert.Equal(100, messages.Count);
     }
@@ -270,13 +271,13 @@ public class DatabaseServiceTests : IDisposable
     [Fact]
     public async Task InsertMessage_WithVeryLongContent_ShouldSucceed()
     {
-        var id = await _databaseService.CreateConversation(
+        var id = await _conversationService.CreateConversation(
             new Conversation(Guid.Empty, "Test", new List<Message>()));
 
         var longContent = new string('a', 100_000);
-        await _databaseService.InsertMessage(id, new Message(longContent), null, null);
+        await _conversationService.InsertMessage(id, new Message(longContent), null, null);
 
-        var messages = await _databaseService.GetMessagesForConversation(
+        var messages = await _conversationService.GetMessagesForConversation(
             new Conversation(id, "Test", new List<Message>()));
 
         Assert.Single(messages);

--- a/avallama.Tests/Services/ModelCacheServiceTests.cs
+++ b/avallama.Tests/Services/ModelCacheServiceTests.cs
@@ -1,0 +1,580 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using avallama.Models;
+using avallama.Services;
+using Microsoft.Data.Sqlite;
+using Xunit;
+
+namespace avallama.Tests.Services;
+
+[Collection("Database Tests")]
+public class ModelCacheServiceTests : IAsyncDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly ModelCacheService _modelCacheService;
+
+    public ModelCacheServiceTests()
+    {
+
+        _connection = new SqliteConnection("Data Source=:memory:");
+        _connection.Open();
+
+        InitializeTestSchema(_connection);
+
+        _modelCacheService = new ModelCacheService(_connection);
+    }
+
+    private static void InitializeTestSchema(SqliteConnection connection)
+    {
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = """
+
+                          CREATE TABLE IF NOT EXISTS model_families (
+                          name TEXT PRIMARY KEY,
+                          description TEXT NOT NULL,
+                          pull_count INTEGER NOT NULL DEFAULT 0,
+                          labels TEXT,
+                          tag_count INTEGER NOT NULL DEFAULT 0,
+                          last_updated TEXT,
+                          cached_at TEXT NOT NULL,
+                          UNIQUE(name)
+                          );
+
+                          CREATE TABLE IF NOT EXISTS ollama_models (
+                          name TEXT PRIMARY KEY,
+                          family_name TEXT NOT NULL,
+                          parameters REAL,
+                          size INTEGER NOT NULL,
+                          format TEXT,
+                          quantization TEXT,
+                          architecture TEXT,
+                          block_count INTEGER,
+                          context_length INTEGER,
+                          embedding_length INTEGER,
+                          additional_info TEXT,
+                          download_status INTEGER NOT NULL DEFAULT 0,
+                          cached_at TEXT NOT NULL,
+                          FOREIGN KEY (family_name) REFERENCES model_families(name) ON DELETE CASCADE
+                          );
+                          """;
+        cmd.ExecuteNonQuery();
+    }
+
+    [Fact]
+    public async Task CacheOllamaModelFamilyAsync_WithNothingInDb_InsertsModelFamilies()
+    {
+        var modelFamilies = new List<OllamaModelFamily>
+        {
+            new(
+                "model-family-1",
+                "Test Model Family 1",
+                100,
+                new List<string> { "tag1", "tag2" },
+                2,
+                DateTime.UtcNow
+            ),
+            new(
+                "model-family-2",
+                "Test Model Family 2",
+                200,
+                new List<string> { "tag3", "tag4" },
+                2,
+                DateTime.UtcNow
+            )
+        };
+
+        await _modelCacheService.CacheOllamaModelFamilyAsync(modelFamilies);
+
+        await using var cmd = _connection.CreateCommand();
+        cmd.CommandText = "SELECT COUNT(*) FROM model_families";
+        var count = (long)(await cmd.ExecuteScalarAsync() ?? 0);
+
+        Assert.Equal(2, count);
+    }
+
+    [Fact]
+    public async Task CacheOllamaModelFamilyAsync_WithExistingDb_UpdatesModelFamilies()
+    {
+        var initialModelFamilies = new List<OllamaModelFamily>
+        {
+            new(
+                "model-family-1",
+                "Initial Description",
+                100,
+                new List<string> { "tag1" },
+                1,
+                DateTime.UtcNow.AddDays(-1)
+            )
+        };
+
+        await _modelCacheService.CacheOllamaModelFamilyAsync(initialModelFamilies);
+
+        var updatedModelFamilies = new List<OllamaModelFamily>
+        {
+            new(
+                "model-family-1",
+                "Updated Description",
+                150,
+                new List<string> { "tag1", "tag2" },
+                2,
+                DateTime.UtcNow
+            )
+        };
+
+        await _modelCacheService.CacheOllamaModelFamilyAsync(updatedModelFamilies);
+
+        await using var cmd = _connection.CreateCommand();
+        cmd.CommandText = "SELECT description, pull_count, labels, tag_count FROM model_families WHERE name = 'model-family-1'";
+        await using var reader = await cmd.ExecuteReaderAsync();
+
+        Assert.True(await reader.ReadAsync());
+        Assert.Equal("Updated Description", reader.GetString(0));
+        Assert.Equal(150, reader.GetInt32(1));
+        var labels = reader.GetString(2);
+        Assert.Contains("tag1", labels);
+        Assert.Contains("tag2", labels);
+        Assert.Equal(2, reader.GetInt32(3));
+    }
+
+    [Fact]
+    public async Task CacheOllamaModelFamilyAsync_WithDelete_RemovesModelFamilies()
+    {
+        var initialModelFamilies = new List<OllamaModelFamily>
+        {
+            new(
+                "model-family-1",
+                "Test Model Family 1",
+                100,
+                new List<string> { "tag1", "tag2" },
+                2,
+                DateTime.UtcNow
+            ),
+            new(
+                "model-family-2",
+                "Test Model Family 2",
+                200,
+                new List<string> { "tag3", "tag4" },
+                2,
+                DateTime.UtcNow
+            )
+        };
+        await _modelCacheService.CacheOllamaModelFamilyAsync(initialModelFamilies);
+
+        var updatedModelFamilies = new List<OllamaModelFamily>
+        {
+            new(
+                "model-family-1",
+                "Test Model Family 1",
+                100,
+                new List<string> { "tag1", "tag2" },
+                2,
+                DateTime.UtcNow
+            )
+        };
+        await _modelCacheService.CacheOllamaModelFamilyAsync(updatedModelFamilies);
+        await using var cmd = _connection.CreateCommand();
+        cmd.CommandText = "SELECT COUNT(*) FROM model_families";
+        var count = (long)(await cmd.ExecuteScalarAsync() ?? 0);
+        Assert.Equal(1, count);
+    }
+
+    [Fact]
+    public async Task CacheOllamaModelAsync_WithNothingInDb_InsertsModels()
+    {
+        var modelFamily = new OllamaModelFamily(
+            "model-1",
+            "Test Model Family 1",
+            100,
+            new List<string> { "tag1", "tag2" },
+            2,
+            DateTime.UtcNow
+        );
+        await _modelCacheService.CacheOllamaModelFamilyAsync(new List<OllamaModelFamily> { modelFamily });
+
+        var models = new List<OllamaModel>
+        {
+            new(
+                "model-1:7b",
+                4096,
+                1.01,
+                "Test Format",
+                new Dictionary<string, string>(),
+                2048,
+                ModelDownloadStatus.Downloaded,
+                false
+            )
+        };
+
+        await _modelCacheService.CacheOllamaModelAsync(models);
+
+        await using var cmd = _connection.CreateCommand();
+        cmd.CommandText = "SELECT COUNT(*) FROM ollama_models";
+        var count = (long)(await cmd.ExecuteScalarAsync() ?? 0);
+
+        Assert.Equal(1, count);
+    }
+
+    [Fact]
+    public async Task CacheOllamaModelAsync_WithExistingDb_UpdatesModels()
+    {
+        var modelFamily = new OllamaModelFamily(
+            "model-1",
+            "Test Model Family 1",
+            100,
+            new List<string> { "tag1", "tag2" },
+            2,
+            DateTime.UtcNow
+        );
+        await _modelCacheService.CacheOllamaModelFamilyAsync(new List<OllamaModelFamily> { modelFamily });
+
+        var initialModel = new List<OllamaModel>
+        {
+            new(
+                "model-1:7b",
+                4096,
+                1.01,
+                "Test Format",
+                new Dictionary<string, string>(),
+                2048,
+                ModelDownloadStatus.Downloading,
+                false
+            )
+        };
+        await _modelCacheService.CacheOllamaModelAsync(initialModel);
+        var updatedModel = new List<OllamaModel>
+        {
+            new(
+                "model-1:7b",
+                8192,
+                1.02,
+                "Updated Format",
+                new Dictionary<string, string>(),
+                4096,
+                ModelDownloadStatus.Downloaded,
+                true
+            )
+        };
+        await _modelCacheService.CacheOllamaModelAsync(updatedModel);
+        await using var cmd = _connection.CreateCommand();
+        cmd.CommandText = "SELECT quantization, parameters, format, download_status FROM ollama_models WHERE name = 'model-1:7b'";
+        await using var reader = await cmd.ExecuteReaderAsync();
+        Assert.True(await reader.ReadAsync());
+        Assert.Equal(8192, reader.GetInt32(0));
+        Assert.Equal(1.02, reader.GetDouble(1));
+        Assert.Equal("Updated Format", reader.GetString(2));
+        Assert.Equal((int)ModelDownloadStatus.Downloaded, reader.GetInt32(3));
+    }
+
+    [Fact]
+    public async Task CacheOllamaModelAsync_WithDelete_RemovesModels()
+    {
+        var modelFamily = new OllamaModelFamily(
+            "model-1",
+            "Test Model Family 1",
+            100,
+            new List<string> { "tag1", "tag2" },
+            2,
+            DateTime.UtcNow
+        );
+        await _modelCacheService.CacheOllamaModelFamilyAsync(new List<OllamaModelFamily> { modelFamily });
+        var initialModels = new List<OllamaModel>
+        {
+            new(
+                "model-1:7b",
+                4096,
+                1.01,
+                "Test Format",
+                new Dictionary<string, string>(),
+                2048,
+                ModelDownloadStatus.Downloaded,
+                false
+            ),
+            new(
+                "model-1:13b",
+                8192,
+                1.02,
+                "Test Format",
+                new Dictionary<string, string>(),
+                4096,
+                ModelDownloadStatus.Downloaded,
+                false
+            )
+        };
+        await _modelCacheService.CacheOllamaModelAsync(initialModels);
+        var updatedModels = new List<OllamaModel>
+        {
+            new(
+                "model-1:7b",
+                4096,
+                1.01,
+                "Test Format",
+                new Dictionary<string, string>(),
+                2048,
+                ModelDownloadStatus.Downloaded,
+                false
+            )
+        };
+        await _modelCacheService.CacheOllamaModelAsync(updatedModels);
+        await using var cmd = _connection.CreateCommand();
+        cmd.CommandText = "SELECT COUNT(*) FROM ollama_models";
+        var count = (long)(await cmd.ExecuteScalarAsync() ?? 0);
+        Assert.Equal(1, count);
+    }
+
+    [Fact]
+    public async Task UpdateOllamaModel_UpdatesModel()
+    {
+        var modelFamily = new OllamaModelFamily(
+            "model-1",
+            "Test Model Family 1",
+            100,
+            new List<string> { "tag1", "tag2" },
+            2,
+            DateTime.UtcNow
+        );
+        await _modelCacheService.CacheOllamaModelFamilyAsync(new List<OllamaModelFamily> { modelFamily });
+
+        var initialModel = new List<OllamaModel>
+        {
+            new(
+                "model-1:7b",
+                4096,
+                1.01,
+                "Test Format",
+                new Dictionary<string, string>(),
+                2048,
+                ModelDownloadStatus.Downloading,
+                false
+            )
+        };
+        await _modelCacheService.CacheOllamaModelAsync(initialModel);
+
+        var details = new Dictionary<string, string>
+        {
+            { "architecture", "llama" },
+            { "context_length", "8192" },
+            { "block_count", "32" },
+            { "embedding_length", "4096" }
+        };
+
+        var modelToUpdate = new OllamaModel
+        {
+            Name = "model-1:7b",
+            Quantization = 4096,
+            Parameters = 1.01,
+            Format = "Test Format",
+            Details = details,
+            Size = 2048,
+            DownloadStatus = ModelDownloadStatus.Downloaded,
+            DownloadProgress = 1.0,
+            RunsSlow = false
+        };
+
+        await _modelCacheService.UpdateOllamaModelAsync(modelToUpdate);
+
+        await using var cmd = _connection.CreateCommand();
+        cmd.CommandText = "SELECT architecture, context_length, block_count, embedding_length, download_status FROM ollama_models WHERE name = 'model-1:7b'";
+        await using var reader = await cmd.ExecuteReaderAsync();
+
+        Assert.True(await reader.ReadAsync());
+        Assert.Equal("llama", reader.GetString(0));
+        Assert.Equal(8192, reader.GetInt32(1));
+        Assert.Equal(32, reader.GetInt32(2));
+        Assert.Equal(4096, reader.GetInt32(3));
+        Assert.Equal((int)ModelDownloadStatus.Downloaded, reader.GetInt32(4));
+    }
+
+    [Fact]
+    public async Task GetCachedOllamaModelFamiliesAsync_ReturnsCachedFamilies()
+    {
+        var modelFamilies = new List<OllamaModelFamily>
+        {
+            new(
+                "model-family-1",
+                "Test Model Family 1",
+                100,
+                new List<string> { "tag1", "tag2" },
+                2,
+                DateTime.UtcNow
+            ),
+            new(
+                "model-family-2",
+                "Test Model Family 2",
+                200,
+                new List<string> { "tag3", "tag4" },
+                2,
+                DateTime.UtcNow
+            )
+        };
+
+        await _modelCacheService.CacheOllamaModelFamilyAsync(modelFamilies);
+
+        var cachedFamilies = await _modelCacheService.GetCachedOllamaModelFamiliesAsync();
+
+        Assert.Equal(2, cachedFamilies.Count);
+        Assert.Contains(cachedFamilies, mf => mf.Name == "model-family-1");
+        Assert.Contains(cachedFamilies, mf => mf.Name == "model-family-2");
+    }
+
+    [Fact]
+    public async Task GetCachedOllamaModelsAsync_ReturnsCachedModels()
+    {
+        var modelFamily = new OllamaModelFamily(
+            "model-1",
+            "Test Model Family 1",
+            100,
+            new List<string> { "tag1", "tag2" },
+            2,
+            DateTime.UtcNow
+        );
+        await _modelCacheService.CacheOllamaModelFamilyAsync(new List<OllamaModelFamily> { modelFamily });
+
+        var models = new List<OllamaModel>
+        {
+            new(
+                "model-1:7b",
+                4096,
+                1.01,
+                "Test Format",
+                new Dictionary<string, string>(),
+                2048,
+                ModelDownloadStatus.Downloaded,
+                false
+            ),
+            new(
+                "model-1:13b",
+                8192,
+                1.02,
+                "Test Format",
+                new Dictionary<string, string>(),
+                4096,
+                ModelDownloadStatus.Downloaded,
+                false
+            )
+        };
+
+        await _modelCacheService.CacheOllamaModelAsync(models);
+
+        var cachedModels = await _modelCacheService.GetCachedOllamaModelsAsync();
+
+        Assert.Equal(2, cachedModels.Count);
+        Assert.Contains(cachedModels, m => m.Name == "model-1:7b");
+        Assert.Contains(cachedModels, m => m.Name == "model-1:13b");
+    }
+
+    // Integration tests, ModelCacheService + DatabaseLock
+
+[Fact]
+    public async Task ConcurrentReads_DoNotBlock()
+    {
+        var modelFamilies = new List<OllamaModelFamily>
+        {
+            new("model-family-1", "Test", 100, new List<string> { "tag1" }, 1, DateTime.UtcNow)
+        };
+        await _modelCacheService.CacheOllamaModelFamilyAsync(modelFamilies);
+
+        var tasks = Enumerable.Range(0, 50)
+            .Select(_ => Task.Run(async () => await _modelCacheService.GetCachedOllamaModelFamiliesAsync()))
+            .ToArray();
+
+        await Task.WhenAll(tasks);
+
+        Assert.All(tasks, t => Assert.True(t.IsCompletedSuccessfully));
+        Assert.All(tasks, t => Assert.Single((IEnumerable)t.Result));
+    }
+
+    [Fact]
+    public async Task MixedReadWriteOperations_AreThreadSafe()
+    {
+        var initialFamily = new OllamaModelFamily("model-1", "Initial", 100,
+            new List<string> { "tag1" }, 1, DateTime.UtcNow);
+        await _modelCacheService.CacheOllamaModelFamilyAsync(new List<OllamaModelFamily> { initialFamily });
+
+        var readTasks = Enumerable.Range(0, 30)
+            .Select(_ => Task.Run(async () => await _modelCacheService.GetCachedOllamaModelFamiliesAsync()));
+
+        var writeTasks = Enumerable.Range(0, 20)
+            .Select(i => Task.Run(async () =>
+            {
+                var updated = new OllamaModelFamily("model-1", $"Updated {i}", 100 + i,
+                    new List<string> { "tag1" }, 1, DateTime.UtcNow);
+                await _modelCacheService.CacheOllamaModelFamilyAsync(new List<OllamaModelFamily> { updated });
+            }));
+
+        await Task.WhenAll(readTasks.Concat(writeTasks));
+
+        var final = await _modelCacheService.GetCachedOllamaModelFamiliesAsync();
+        Assert.Single(final);
+    }
+
+    [Fact]
+    public async Task HighVolumeUpdates_MaintainConsistency()
+    {
+        var modelFamily = new OllamaModelFamily("model-1", "Test", 100,
+            new List<string> { "tag1" }, 1, DateTime.UtcNow);
+        await _modelCacheService.CacheOllamaModelFamilyAsync(new List<OllamaModelFamily> { modelFamily });
+
+        var model = new OllamaModel("model-1:7b", 4096, 1.0, "gguf",
+            new Dictionary<string, string>(), 2048, ModelDownloadStatus.Downloaded, false);
+        await _modelCacheService.CacheOllamaModelAsync(new List<OllamaModel> { model });
+
+        var tasks = Enumerable.Range(0, 100)
+            .Select(i => Task.Run(async () =>
+            {
+                var updated = new OllamaModel
+                {
+                    Name = "model-1:7b",
+                    Quantization = 4096 + i,
+                    Parameters = 1.0 + i,
+                    Format = "gguf",
+                    Details = new Dictionary<string, string> { ["iteration"] = i.ToString() },
+                    Size = 2048 + i,
+                    DownloadStatus = ModelDownloadStatus.Downloaded,
+                    DownloadProgress = 1.0,
+                    RunsSlow = false
+                };
+                await _modelCacheService.UpdateOllamaModelAsync(updated);
+            }))
+            .ToArray();
+
+        await Task.WhenAll(tasks);
+
+        var cached = await _modelCacheService.GetCachedOllamaModelsAsync();
+        Assert.Single(cached);
+        Assert.Equal("model-1:7b", cached[0].Name);
+    }
+
+    [Fact]
+    public async Task ConcurrentReadsDuringBulkWrite_Succeed()
+    {
+        var modelFamilies = Enumerable.Range(0, 100)
+            .Select(i => new OllamaModelFamily($"family-{i}", $"Desc {i}", i,
+                new List<string> { $"tag{i}" }, 1, DateTime.UtcNow))
+            .ToList();
+
+        var writeTask = Task.Run(async () =>
+            await _modelCacheService.CacheOllamaModelFamilyAsync(modelFamilies));
+
+        var readTasks = Enumerable.Range(0, 50)
+            .Select(_ => Task.Run(async () => await _modelCacheService.GetCachedOllamaModelFamiliesAsync()))
+            .ToArray();
+
+        await Task.WhenAll(readTasks.Append(writeTask));
+
+        var final = await _modelCacheService.GetCachedOllamaModelFamiliesAsync();
+        Assert.Equal(100, final.Count);
+    }
+
+
+    public async ValueTask DisposeAsync()
+    {
+        await Task.Delay(100);
+
+        await _connection.CloseAsync();
+        await _connection.DisposeAsync();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/avallama.Tests/Utilities/DatabaseLockTests.cs
+++ b/avallama.Tests/Utilities/DatabaseLockTests.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using avallama.Utilities;
+using Xunit;
+
+namespace avallama.Tests.Utilities;
+
+[Collection("Database Tests")]
+public class DatabaseLockTests
+{
+    [Fact]
+    public async Task DatabaseLock_Allows_MultipleReaders()
+    {
+        var lockInstance = DatabaseLock.Instance;
+        var concurrent = 0;
+        var maxConcurrent = 0;
+        var allStarted = new CountdownEvent(10);
+
+        var tasks = Enumerable.Range(0, 10).Select(_ => Task.Run(() =>
+        {
+            using (lockInstance.AcquireReadLock())
+            {
+                var cur = Interlocked.Increment(ref concurrent);
+                allStarted.Signal();
+
+                SpinWait.SpinUntil(() =>
+                {
+                    var prev = Volatile.Read(ref maxConcurrent);
+                    return cur <= prev || Interlocked.CompareExchange(ref maxConcurrent, cur, prev) == prev;
+                });
+
+                allStarted.Wait(TimeSpan.FromSeconds(5));
+                Thread.Sleep(50);
+
+                Interlocked.Decrement(ref concurrent);
+            }
+        })).ToArray();
+
+        await Task.WhenAll(tasks);
+
+        Assert.True(maxConcurrent >= 2, $"Expected at least 2 concurrent readers, got {maxConcurrent}");
+    }
+
+    [Fact]
+    public async Task DatabaseLock_WriteLock_IsExclusive()
+    {
+        var lockInstance = DatabaseLock.Instance;
+        var writerStarted = new TaskCompletionSource();
+        var writerRelease = new TaskCompletionSource();
+
+        var writer = Task.Run(() =>
+        {
+            using (lockInstance.AcquireWriteLock())
+            {
+                writerStarted.SetResult();
+                writerRelease.Task.Wait();
+            }
+        });
+
+        await writerStarted.Task;
+
+        var readerAcquired = false;
+        var reader = Task.Run(() =>
+        {
+            using (lockInstance.AcquireReadLock())
+            {
+                readerAcquired = true;
+            }
+        });
+
+        await Task.Delay(100);
+        Assert.False(readerAcquired, "Reader should not acquire lock while writer holds it.");
+
+        writerRelease.SetResult();
+        await Task.WhenAll(writer, reader);
+        Assert.True(readerAcquired, "Reader should acquire lock after writer releases it.");
+    }
+
+    [Fact]
+    public void DatabaseLock_IsSingleton()
+    {
+        var instance1 = DatabaseLock.Instance;
+        var instance2 = DatabaseLock.Instance;
+
+        Assert.Same(instance1, instance2);
+    }
+}

--- a/avallama/App.axaml.cs
+++ b/avallama/App.axaml.cs
@@ -76,7 +76,7 @@ public partial class App : Application
         _ollamaService = services.GetRequiredService<OllamaService>();
         _dialogService = services.GetRequiredService<DialogService>();
         _databaseInitService = services.GetRequiredService<DatabaseInitService>();
-        SharedDbConnection = _databaseInitService.GetOpenConnectionAsync().GetAwaiter().GetResult();
+        SharedDbConnection = _databaseInitService.InitializeDatabaseAsync().GetAwaiter().GetResult();
 
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {

--- a/avallama/Constants/SortingOption.cs
+++ b/avallama/Constants/SortingOption.cs
@@ -9,5 +9,7 @@ public enum SortingOption
     ParametersDescending,
     ParametersAscending,
     SizeDescending,
-    SizeAscending
+    SizeAscending,
+    PullCountDescending,
+    PullCountAscending
 }

--- a/avallama/Extensions/ServiceCollectionExtensions.cs
+++ b/avallama/Extensions/ServiceCollectionExtensions.cs
@@ -40,8 +40,8 @@ public static class ServiceCollectionExtensions
         collection.AddTransient<DatabaseInitService>();
         collection.AddTransient<IDatabaseInitService>(sp => sp.GetRequiredService<DatabaseInitService>());
 
-        collection.AddSingleton<DatabaseService>();
-        collection.AddSingleton<IDatabaseService>(sp => sp.GetRequiredService<DatabaseService>());
+        collection.AddSingleton<ConversationService>();
+        collection.AddSingleton<IConversationService>(sp => sp.GetRequiredService<ConversationService>());
 
         collection.AddSingleton<OllamaService>();
         collection.AddSingleton<IOllamaService>(sp => sp.GetRequiredService<OllamaService>());

--- a/avallama/Models/OllamaModel.cs
+++ b/avallama/Models/OllamaModel.cs
@@ -1,10 +1,9 @@
 // Copyright (c) Márk Csörgő and Martin Bartos
 // Licensed under the MIT License. See LICENSE file for details.
 
+using System;
 using System.Collections.Generic;
-using System.Text;
 using CommunityToolkit.Mvvm.ComponentModel;
-using Tmds.DBus.Protocol;
 
 namespace avallama.Models;
 
@@ -86,4 +85,20 @@ public partial class OllamaModel : ObservableObject
         Format = string.Empty;
         Details = null;
     }
+}
+
+public class OllamaModelFamily(
+    string name,
+    string description,
+    long pullCount,
+    IList<string> labels,
+    int tagCount,
+    DateTime lastUpdated)
+{
+    public string Name { get; set; } = name;
+    public string Description { get; set; } = description;
+    public long PullCount { get; set; } = pullCount;
+    public IList<string> Labels { get; set; } = labels;
+    public int TagCount { get; set; } = tagCount;
+    public DateTime LastUpdated { get; set; } = lastUpdated;
 }

--- a/avallama/Services/ConversationService.cs
+++ b/avallama/Services/ConversationService.cs
@@ -20,7 +20,7 @@ internal static class Roles
     public const string Assistant = "assistant";
 }
 
-public interface IDatabaseService
+public interface IConversationService
 {
     public Task<Guid> CreateConversation(Conversation conversation);
     public Task InsertMessage(Guid conversationId, Message message, string? modelName, double? tokenPerSec);
@@ -29,12 +29,11 @@ public interface IDatabaseService
     public Task<ObservableCollection<Message>> GetMessagesForConversation(Conversation conversation);
 }
 
-public class DatabaseService : IDatabaseService, IDisposable
+public class ConversationService : IConversationService, IDisposable
 {
     private readonly SqliteConnection _connection;
-    private readonly SemaphoreSlim _semaphore = new(1, 1);
 
-    public DatabaseService(SqliteConnection? testConnection = null)
+    public ConversationService(SqliteConnection? testConnection = null)
     {
         if (testConnection is not null)
         {
@@ -57,9 +56,7 @@ public class DatabaseService : IDatabaseService, IDisposable
     public async Task<Guid> CreateConversation(Conversation conversation)
     {
         var conversationId = Guid.NewGuid();
-
-        await _semaphore.WaitAsync();
-        try
+        using (DatabaseLock.Instance.AcquireWriteLock())
         {
             await using var cmd = _connection.CreateCommand();
             cmd.CommandText =
@@ -79,10 +76,6 @@ public class DatabaseService : IDatabaseService, IDisposable
                 throw;
             }
         }
-        finally
-        {
-            _semaphore.Release();
-        }
 
         return conversationId;
     }
@@ -91,8 +84,7 @@ public class DatabaseService : IDatabaseService, IDisposable
     {
         if (message is FailedMessage) return;
 
-        await _semaphore.WaitAsync();
-        try
+        using (DatabaseLock.Instance.AcquireWriteLock())
         {
             await using var transaction = await _connection.BeginTransactionAsync();
             var now = DateTime.Now;
@@ -133,17 +125,12 @@ public class DatabaseService : IDatabaseService, IDisposable
                 throw;
             }
         }
-        finally
-        {
-            _semaphore.Release();
-        }
     }
 
     public async Task<ObservableStack<Conversation>> GetConversations()
     {
         ObservableStack<Conversation> conversations;
-        await _semaphore.WaitAsync();
-        try
+        using (DatabaseLock.Instance.AcquireReadLock())
         {
             await using var cmd = _connection.CreateCommand();
             cmd.CommandText = "SELECT * FROM conversations ORDER BY last_message_sent_at DESC";
@@ -180,11 +167,6 @@ public class DatabaseService : IDatabaseService, IDisposable
                     lastModels.GetValueOrDefault(conv.ConversationId,
                         "llama3.2:2b"); // this default could be set in settings?
             }
-
-        }
-        finally
-        {
-            _semaphore.Release();
         }
 
         return conversations;
@@ -240,8 +222,7 @@ public class DatabaseService : IDatabaseService, IDisposable
 
     public async Task<bool> UpdateConversationTitle(Conversation conversation)
     {
-        await _semaphore.WaitAsync();
-        try
+        using (DatabaseLock.Instance.AcquireWriteLock())
         {
             await using var cmd = _connection.CreateCommand();
             cmd.CommandText = "UPDATE conversations SET title = @title WHERE id = @ConversationId";
@@ -258,17 +239,12 @@ public class DatabaseService : IDatabaseService, IDisposable
                 throw;
             }
         }
-        finally
-        {
-            _semaphore.Release();
-        }
     }
 
     public async Task<ObservableCollection<Message>> GetMessagesForConversation(Conversation conversation)
     {
         ObservableCollection<Message> messages;
-        await _semaphore.WaitAsync();
-        try
+        using (DatabaseLock.Instance.AcquireReadLock())
         {
             messages = [];
             await using var cmd = _connection.CreateCommand();
@@ -298,17 +274,12 @@ public class DatabaseService : IDatabaseService, IDisposable
                 throw;
             }
         }
-        finally
-        {
-            _semaphore.Release();
-        }
 
         return messages;
     }
 
     public void Dispose()
     {
-        _semaphore.Dispose();
         _connection.Dispose();
         GC.SuppressFinalize(this);
     }

--- a/avallama/Services/ModelCacheService.cs
+++ b/avallama/Services/ModelCacheService.cs
@@ -1,0 +1,545 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using avallama.Constants;
+using avallama.Models;
+using avallama.Utilities;
+using Microsoft.Data.Sqlite;
+
+namespace avallama.Services;
+
+public interface IModelCacheService
+{
+    public Task CacheOllamaModelFamilyAsync(IList<OllamaModelFamily> modelFamilies);
+    public Task CacheOllamaModelAsync(IList<OllamaModel> models);
+    public Task UpdateOllamaModelAsync(OllamaModel model);
+    public Task<IList<OllamaModel>> GetCachedOllamaModelsAsync();
+    public Task<IList<OllamaModelFamily>> GetCachedOllamaModelFamiliesAsync();
+}
+
+public class ModelCacheService : IModelCacheService
+{
+    private readonly SqliteConnection _connection;
+
+    public ModelCacheService(SqliteConnection? testConnection = null)
+    {
+        if (testConnection is not null)
+        {
+            _connection = testConnection;
+            _connection.Open();
+            return;
+        }
+
+        var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+        var appDir = Path.Combine(appData, "avallama");
+        if (!Directory.Exists(appDir))
+            Directory.CreateDirectory(appDir);
+
+        var dbPath = Path.Combine(appDir, "avallama.db");
+        var connectionString = $"Data Source={dbPath}";
+        _connection = new SqliteConnection(connectionString);
+        _connection.Open();
+    }
+
+    public async Task CacheOllamaModelFamilyAsync(IList<OllamaModelFamily> modelFamilies)
+    {
+        var now = DateTime.Now;
+
+        using (DatabaseLock.Instance.AcquireWriteLock())
+        {
+            await using var transaction = _connection.BeginTransaction();
+
+            await using var cmd = _connection.CreateCommand();
+            cmd.CommandText =
+                "SELECT name, description, pull_count, labels, tag_count, last_updated FROM model_families";
+            await using var reader = await cmd.ExecuteReaderAsync();
+            var existingModelFamilies = new Dictionary<string, OllamaModelFamily>();
+            while (await reader.ReadAsync())
+            {
+                var name = reader.GetString(0);
+                var description = reader.IsDBNull(1) ? string.Empty : reader.GetString(1);
+                var pullCount = reader.GetInt32(2);
+                var labels = reader.IsDBNull(3)
+                    ? []
+                    : JsonSerializer.Deserialize<List<string>>(reader.GetString(3)) ?? [];
+                var tagCount = reader.GetInt32(4);
+                var lastUpdated = reader.IsDBNull(5) ? DateTime.MinValue : reader.GetDateTime(5);
+
+                var modelFamily = new OllamaModelFamily(
+                    name,
+                    description,
+                    pullCount,
+                    labels,
+                    tagCount,
+                    lastUpdated);
+
+                existingModelFamilies[name] = modelFamily;
+            }
+
+            reader.Close();
+
+            var newFamilies = modelFamilies.ToDictionary(f => f.Name);
+
+            var toInsert = modelFamilies.Where(f => !existingModelFamilies.ContainsKey(f.Name));
+            var toDelete = existingModelFamilies.Values.Where(f => !newFamilies.ContainsKey(f.Name));
+            var toUpdate = modelFamilies
+                .Where(f => existingModelFamilies.ContainsKey(f.Name))
+                .Where(f => HasOllamaModelFamilyChanged(f, existingModelFamilies[f.Name]));
+
+            var insertList = toInsert.ToList();
+            if (insertList.Count != 0)
+            {
+                await using var insertCmd = _connection.CreateCommand();
+                var values = string.Join(", ", insertList.Select((_, i) =>
+                    $"(@name{i}, @description{i}, @pullCount{i}, @labels{i}, @tagCount{i}, @lastUpdated{i}, @cachedAt{i})"));
+
+                insertCmd.CommandText = $"""
+                                                 INSERT INTO model_families (name, description, pull_count, labels, tag_count, last_updated, cached_at)
+                                                 VALUES {values}
+                                         """;
+
+                for (var i = 0; i < insertList.Count; i++)
+                {
+                    var family = insertList[i];
+                    insertCmd.Parameters.AddWithValue($"@name{i}", family.Name);
+                    insertCmd.Parameters.AddWithValue($"@description{i}", family.Description);
+                    insertCmd.Parameters.AddWithValue($"@pullCount{i}", family.PullCount);
+                    insertCmd.Parameters.AddWithValue($"@labels{i}", JsonSerializer.Serialize(family.Labels));
+                    insertCmd.Parameters.AddWithValue($"@tagCount{i}", family.TagCount);
+                    insertCmd.Parameters.AddWithValue($"@lastUpdated{i}", family.LastUpdated);
+                    insertCmd.Parameters.AddWithValue($"@cachedAt{i}", now);
+                }
+
+                await insertCmd.ExecuteNonQueryAsync();
+            }
+
+            var updateList = toUpdate.ToList();
+            if (updateList.Count != 0)
+            {
+                await using var updateCmd = _connection.CreateCommand();
+                var nameParams = string.Join(", ", updateList.Select((_, i) => $"@name{i}"));
+
+                updateCmd.CommandText = $"""
+                                                 UPDATE model_families
+                                                 SET description = CASE name {string.Join(" ", updateList.Select((_, i) => $"WHEN @name{i} THEN @description{i}"))} END,
+                                                     pull_count = CASE name {string.Join(" ", updateList.Select((_, i) => $"WHEN @name{i} THEN @pullCount{i}"))} END,
+                                                     labels = CASE name {string.Join(" ", updateList.Select((_, i) => $"WHEN @name{i} THEN @labels{i}"))} END,
+                                                     tag_count = CASE name {string.Join(" ", updateList.Select((_, i) => $"WHEN @name{i} THEN @tagCount{i}"))} END,
+                                                     last_updated = CASE name {string.Join(" ", updateList.Select((_, i) => $"WHEN @name{i} THEN @lastUpdated{i}"))} END,
+                                                     cached_at = @cachedAt
+                                                 WHERE name IN ({nameParams})
+                                         """;
+
+                for (var i = 0; i < updateList.Count; i++)
+                {
+                    var family = updateList[i];
+                    updateCmd.Parameters.AddWithValue($"@name{i}", family.Name);
+                    updateCmd.Parameters.AddWithValue($"@description{i}", family.Description);
+                    updateCmd.Parameters.AddWithValue($"@pullCount{i}", family.PullCount);
+                    updateCmd.Parameters.AddWithValue($"@labels{i}", JsonSerializer.Serialize(family.Labels));
+                    updateCmd.Parameters.AddWithValue($"@tagCount{i}", family.TagCount);
+                    updateCmd.Parameters.AddWithValue($"@lastUpdated{i}", family.LastUpdated);
+                }
+
+                updateCmd.Parameters.AddWithValue("@cachedAt", now);
+
+                await updateCmd.ExecuteNonQueryAsync();
+            }
+
+            var deleteList = toDelete.ToList();
+            if (deleteList.Count != 0)
+            {
+                await using var deleteCmd = _connection.CreateCommand();
+                var nameParams = string.Join(", ", deleteList.Select((_, i) => $"@name{i}"));
+                deleteCmd.CommandText = $"DELETE FROM model_families WHERE name IN ({nameParams})";
+
+                for (var i = 0; i < deleteList.Count; i++)
+                {
+                    deleteCmd.Parameters.AddWithValue($"@name{i}", deleteList[i].Name);
+                }
+
+                await deleteCmd.ExecuteNonQueryAsync();
+            }
+
+            transaction.Commit();
+        }
+    }
+
+    private static bool HasOllamaModelFamilyChanged(OllamaModelFamily newFamily, OllamaModelFamily existingFamily)
+    {
+        return newFamily.Description != existingFamily.Description ||
+               newFamily.PullCount != existingFamily.PullCount ||
+               newFamily.TagCount != existingFamily.TagCount ||
+               newFamily.LastUpdated != existingFamily.LastUpdated ||
+               !newFamily.Labels.SequenceEqual(existingFamily.Labels);
+    }
+
+    public async Task<IList<OllamaModelFamily>> GetCachedOllamaModelFamiliesAsync()
+    {
+        var modelFamilies = new List<OllamaModelFamily>();
+        using (DatabaseLock.Instance.AcquireReadLock())
+        {
+
+            await using var cmd = _connection.CreateCommand();
+            cmd.CommandText =
+                "SELECT name, description, pull_count, labels, tag_count, last_updated FROM model_families ORDER BY pull_count DESC";
+            await using var reader = await cmd.ExecuteReaderAsync();
+            while (await reader.ReadAsync())
+            {
+                var name = reader.GetString(0);
+                var description = reader.IsDBNull(1) ? string.Empty : reader.GetString(1);
+                var pullCount = reader.GetInt32(2);
+                var labels = reader.IsDBNull(3)
+                    ? []
+                    : JsonSerializer.Deserialize<List<string>>(reader.GetString(3)) ?? [];
+                var tagCount = reader.GetInt32(4);
+                var lastUpdated = reader.IsDBNull(5) ? DateTime.MinValue : reader.GetDateTime(5);
+
+                var modelFamily = new OllamaModelFamily(name, description, pullCount, labels, tagCount, lastUpdated);
+
+                modelFamilies.Add(modelFamily);
+            }
+        }
+
+        return modelFamilies;
+    }
+
+    public async Task CacheOllamaModelAsync(IList<OllamaModel> models)
+    {
+        var now = DateTime.Now;
+
+        using (DatabaseLock.Instance.AcquireWriteLock())
+        {
+            await using var transaction = _connection.BeginTransaction();
+
+            await using var cmd = _connection.CreateCommand();
+            cmd.CommandText = """
+                                      SELECT name, family_name, parameters, size, format, quantization,
+                                             architecture, block_count, context_length, embedding_length,
+                                             additional_info, download_status
+                                      FROM ollama_models
+                              """;
+
+            await using var reader = await cmd.ExecuteReaderAsync();
+            var existingModels = new Dictionary<string, OllamaModel>();
+
+            while (await reader.ReadAsync())
+            {
+                var details = new Dictionary<string, string>();
+
+                if (!reader.IsDBNull(6)) details["architecture"] = reader.GetString(6);
+                if (!reader.IsDBNull(7)) details["block_count"] = reader.GetInt32(7).ToString();
+                if (!reader.IsDBNull(8)) details["context_length"] = reader.GetInt32(8).ToString();
+                if (!reader.IsDBNull(9)) details["embedding_length"] = reader.GetInt32(9).ToString();
+
+                if (!reader.IsDBNull(10))
+                {
+                    var additionalInfo = JsonSerializer.Deserialize<Dictionary<string, string>>(reader.GetString(10));
+                    if (additionalInfo != null)
+                    {
+                        foreach (var kvp in additionalInfo)
+                        {
+                            details[kvp.Key] = kvp.Value;
+                        }
+                    }
+                }
+
+                var model = new OllamaModel
+                {
+                    Name = reader.GetString(0),
+                    Parameters = reader.IsDBNull(2) ? null : reader.GetDouble(2),
+                    Size = reader.GetInt64(3),
+                    Format = reader.IsDBNull(4) ? null : reader.GetString(4),
+                    Quantization = reader.IsDBNull(5) ? null : reader.GetInt32(5),
+                    Details = details.Count > 0 ? details : null,
+                    DownloadStatus = (ModelDownloadStatus)reader.GetInt32(11)
+                };
+
+                existingModels[model.Name] = model;
+            }
+
+            reader.Close();
+
+            var newModels = models.ToDictionary(m => m.Name);
+            var toInsert = models.Where(m => !existingModels.ContainsKey(m.Name));
+            var toDelete = existingModels.Values.Where(m => !newModels.ContainsKey(m.Name));
+            var toUpdate = models
+                .Where(m => existingModels.ContainsKey(m.Name))
+                .Where(m => HasOllamaModelChanged(m, existingModels[m.Name]));
+
+            var insertList = toInsert.ToList();
+            if (insertList.Count != 0)
+            {
+                await using var insertCmd = _connection.CreateCommand();
+                var values = string.Join(", ", insertList.Select((_, i) =>
+                    $"(@name{i}, @familyName{i}, @parameters{i}, @size{i}, @format{i}, @quantization{i}, @architecture{i}, @blockCount{i}, @contextLength{i}, @embeddingLength{i}, @additionalInfo{i}, @downloadStatus{i}, @cachedAt{i})"));
+
+                insertCmd.CommandText = $"""
+                                         INSERT INTO ollama_models (name, family_name, parameters, size, format, quantization, architecture, block_count, context_length, embedding_length, additional_info, download_status, cached_at)
+                                         VALUES {values}
+                                         """;
+
+                for (var i = 0; i < insertList.Count; i++)
+                {
+                    var model = insertList[i];
+                    var (architecture, blockCount, contextLength, embeddingLength, additionalInfo) =
+                        ExtractModelDetails(model.Details);
+
+                    insertCmd.Parameters.AddWithValue($"@name{i}", model.Name);
+                    insertCmd.Parameters.AddWithValue($"@familyName{i}", ExtractFamilyName(model.Name));
+                    insertCmd.Parameters.AddWithValue($"@parameters{i}", model.Parameters ?? (object)DBNull.Value);
+                    insertCmd.Parameters.AddWithValue($"@size{i}", model.Size);
+                    insertCmd.Parameters.AddWithValue($"@format{i}", model.Format ?? (object)DBNull.Value);
+                    insertCmd.Parameters.AddWithValue($"@quantization{i}", model.Quantization ?? (object)DBNull.Value);
+                    insertCmd.Parameters.AddWithValue($"@architecture{i}", architecture ?? (object)DBNull.Value);
+                    insertCmd.Parameters.AddWithValue($"@blockCount{i}", blockCount ?? (object)DBNull.Value);
+                    insertCmd.Parameters.AddWithValue($"@contextLength{i}", contextLength ?? (object)DBNull.Value);
+                    insertCmd.Parameters.AddWithValue($"@embeddingLength{i}", embeddingLength ?? (object)DBNull.Value);
+                    insertCmd.Parameters.AddWithValue($"@additionalInfo{i}", additionalInfo ?? (object)DBNull.Value);
+                    insertCmd.Parameters.AddWithValue($"@downloadStatus{i}", (int)model.DownloadStatus);
+                    insertCmd.Parameters.AddWithValue($"@cachedAt{i}", now);
+                }
+
+                await insertCmd.ExecuteNonQueryAsync();
+            }
+
+            var updateList = toUpdate.ToList();
+            if (updateList.Count != 0)
+            {
+                await using var updateCmd = _connection.CreateCommand();
+                var nameParams = string.Join(", ", updateList.Select((_, i) => $"@name{i}"));
+
+                updateCmd.CommandText = $"""
+                                         UPDATE ollama_models
+                                         SET family_name = CASE name {string.Join(" ", updateList.Select((_, i) => $"WHEN @name{i} THEN @familyName{i}"))} END,
+                                             parameters = CASE name {string.Join(" ", updateList.Select((_, i) => $"WHEN @name{i} THEN @parameters{i}"))} END,
+                                             size = CASE name {string.Join(" ", updateList.Select((_, i) => $"WHEN @name{i} THEN @size{i}"))} END,
+                                             format = CASE name {string.Join(" ", updateList.Select((_, i) => $"WHEN @name{i} THEN @format{i}"))} END,
+                                             quantization = CASE name {string.Join(" ", updateList.Select((_, i) => $"WHEN @name{i} THEN @quantization{i}"))} END,
+                                             architecture = CASE name {string.Join(" ", updateList.Select((_, i) => $"WHEN @name{i} THEN @architecture{i}"))} END,
+                                             block_count = CASE name {string.Join(" ", updateList.Select((_, i) => $"WHEN @name{i} THEN @blockCount{i}"))} END,
+                                             context_length = CASE name {string.Join(" ", updateList.Select((_, i) => $"WHEN @name{i} THEN @contextLength{i}"))} END,
+                                             embedding_length = CASE name {string.Join(" ", updateList.Select((_, i) => $"WHEN @name{i} THEN @embeddingLength{i}"))} END,
+                                             additional_info = CASE name {string.Join(" ", updateList.Select((_, i) => $"WHEN @name{i} THEN @additionalInfo{i}"))} END,
+                                             download_status = CASE name {string.Join(" ", updateList.Select((_, i) => $"WHEN @name{i} THEN @downloadStatus{i}"))} END,
+                                             cached_at = @cachedAt
+                                         WHERE name IN ({nameParams})
+                                         """;
+
+                for (var i = 0; i < updateList.Count; i++)
+                {
+                    var model = updateList[i];
+                    var (architecture, blockCount, contextLength, embeddingLength, additionalInfo) =
+                        ExtractModelDetails(model.Details);
+
+                    updateCmd.Parameters.AddWithValue($"@name{i}", model.Name);
+                    updateCmd.Parameters.AddWithValue($"@familyName{i}", ExtractFamilyName(model.Name));
+                    updateCmd.Parameters.AddWithValue($"@parameters{i}", model.Parameters ?? (object)DBNull.Value);
+                    updateCmd.Parameters.AddWithValue($"@size{i}", model.Size);
+                    updateCmd.Parameters.AddWithValue($"@format{i}", model.Format ?? (object)DBNull.Value);
+                    updateCmd.Parameters.AddWithValue($"@quantization{i}", model.Quantization ?? (object)DBNull.Value);
+                    updateCmd.Parameters.AddWithValue($"@architecture{i}", architecture ?? (object)DBNull.Value);
+                    updateCmd.Parameters.AddWithValue($"@blockCount{i}", blockCount ?? (object)DBNull.Value);
+                    updateCmd.Parameters.AddWithValue($"@contextLength{i}", contextLength ?? (object)DBNull.Value);
+                    updateCmd.Parameters.AddWithValue($"@embeddingLength{i}", embeddingLength ?? (object)DBNull.Value);
+                    updateCmd.Parameters.AddWithValue($"@additionalInfo{i}", additionalInfo ?? (object)DBNull.Value);
+                    updateCmd.Parameters.AddWithValue($"@downloadStatus{i}", (int)model.DownloadStatus);
+                }
+
+                updateCmd.Parameters.AddWithValue("@cachedAt", now);
+                await updateCmd.ExecuteNonQueryAsync();
+            }
+
+            var deleteList = toDelete.ToList();
+            if (deleteList.Count != 0)
+            {
+                await using var deleteCmd = _connection.CreateCommand();
+                var nameParams = string.Join(", ", deleteList.Select((_, i) => $"@name{i}"));
+                deleteCmd.CommandText = $"DELETE FROM ollama_models WHERE name IN ({nameParams})";
+
+                for (var i = 0; i < deleteList.Count; i++)
+                {
+                    deleteCmd.Parameters.AddWithValue($"@name{i}", deleteList[i].Name);
+                }
+
+                await deleteCmd.ExecuteNonQueryAsync();
+            }
+
+            transaction.Commit();
+        }
+    }
+
+    private static (string?, int?, int?, int?, string?) ExtractModelDetails(IDictionary<string, string>? details)
+    {
+        if (details == null) return (null, null, null, null, null);
+
+        var architecture = details.TryGetValue("architecture", out var arch) ? arch : null;
+        var blockCount = details.TryGetValue("block_count", out var bc) && int.TryParse(bc, out var bcVal)
+            ? bcVal
+            : (int?)null;
+        var contextLength = details.TryGetValue("context_length", out var cl) && int.TryParse(cl, out var clVal)
+            ? clVal
+            : (int?)null;
+        var embeddingLength = details.TryGetValue("embedding_length", out var el) && int.TryParse(el, out var elVal)
+            ? elVal
+            : (int?)null;
+
+        var additionalDetails = details
+            .Where(kvp => kvp.Key is not ("architecture" or "block_count" or "context_length" or "embedding_length"))
+            .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+
+        var additionalInfo = additionalDetails.Count > 0 ? JsonSerializer.Serialize(additionalDetails) : null;
+
+        return (architecture, blockCount, contextLength, embeddingLength, additionalInfo);
+    }
+
+    private static string ExtractFamilyName(string modelName)
+    {
+        var colonIndex = modelName.IndexOf(':');
+        return colonIndex > 0 ? modelName[..colonIndex] : modelName;
+    }
+
+    private static bool HasOllamaModelChanged(OllamaModel newModel, OllamaModel existingModel)
+    {
+        const double epsilon = 1e-9;
+
+        bool parametersChanged;
+        if (!newModel.Parameters.HasValue && !existingModel.Parameters.HasValue)
+        {
+            parametersChanged = false;
+        }
+        else if (!newModel.Parameters.HasValue || !existingModel.Parameters.HasValue)
+        {
+            parametersChanged = true;
+        }
+        else
+        {
+            parametersChanged = Math.Abs(newModel.Parameters.Value - existingModel.Parameters.Value) > epsilon;
+        }
+
+        if (parametersChanged ||
+            newModel.Size != existingModel.Size ||
+            newModel.Format != existingModel.Format ||
+            newModel.Quantization != existingModel.Quantization ||
+            newModel.DownloadStatus != existingModel.DownloadStatus)
+        {
+            return true;
+        }
+
+        if (newModel.Details == null && existingModel.Details == null) return false;
+        if (newModel.Details == null || existingModel.Details == null) return true;
+
+        if (newModel.Details.Count != existingModel.Details.Count) return true;
+        foreach (var kv in newModel.Details)
+        {
+            if (!existingModel.Details.TryGetValue(kv.Key, out var otherVal) ||
+                !string.Equals(kv.Value, otherVal, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+
+    public async Task UpdateOllamaModelAsync(OllamaModel model)
+    {
+        var now = DateTime.Now;
+
+        using (DatabaseLock.Instance.AcquireWriteLock())
+        {
+            await using var transaction = _connection.BeginTransaction();
+
+            await using var cmd = _connection.CreateCommand();
+
+            cmd.CommandText = """
+                              UPDATE ollama_models
+                              SET parameters = @parameters,
+                                  size = @size,
+                                  format = @format,
+                                  quantization = @quantization,
+                                  architecture = @architecture,
+                                  block_count = @blockCount,
+                                  context_length = @contextLength,
+                                  embedding_length = @embeddingLength,
+                                  additional_info = @additionalInfo,
+                                  download_status = @downloadStatus,
+                                  cached_at = @cachedAt
+                              WHERE name = @name
+                              """;
+
+            var (architecture, blockCount, contextLength, embeddingLength, additionalInfo) =
+                ExtractModelDetails(model.Details);
+
+            cmd.Parameters.AddWithValue("@name", model.Name);
+            cmd.Parameters.AddWithValue("@parameters", model.Parameters ?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@size", model.Size);
+            cmd.Parameters.AddWithValue("@format", model.Format ?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@quantization", model.Quantization ?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@architecture", architecture ?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@blockCount", blockCount ?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@contextLength", contextLength ?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@embeddingLength", embeddingLength ?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@additionalInfo", additionalInfo ?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@downloadStatus", (int)model.DownloadStatus);
+            cmd.Parameters.AddWithValue("@cachedAt", now);
+
+            await cmd.ExecuteNonQueryAsync();
+            transaction.Commit();
+        }
+    }
+
+    public async Task<IList<OllamaModel>> GetCachedOllamaModelsAsync()
+    {
+        var models = new List<OllamaModel>();
+
+        using (DatabaseLock.Instance.AcquireReadLock())
+        {
+            await using var cmd = _connection.CreateCommand();
+            cmd.CommandText =
+                "SELECT name, family_name, parameters, size, format, quantization, architecture, block_count, context_length, embedding_length, additional_info, download_status FROM ollama_models ORDER BY name NULLS LAST";
+            await using var reader = await cmd.ExecuteReaderAsync();
+            while (await reader.ReadAsync())
+            {
+                var details = new Dictionary<string, string>();
+
+                if (!reader.IsDBNull(6)) details["architecture"] = reader.GetString(6);
+                if (!reader.IsDBNull(7)) details["block_count"] = reader.GetInt32(7).ToString();
+                if (!reader.IsDBNull(8)) details["context_length"] = reader.GetInt32(8).ToString();
+                if (!reader.IsDBNull(9)) details["embedding_length"] = reader.GetInt32(9).ToString();
+
+                if (!reader.IsDBNull(10))
+                {
+                    var additionalInfo = JsonSerializer.Deserialize<Dictionary<string, string>>(reader.GetString(10));
+                    if (additionalInfo != null)
+                    {
+                        foreach (var kvp in additionalInfo)
+                        {
+                            details[kvp.Key] = kvp.Value;
+                        }
+                    }
+                }
+
+                var model = new OllamaModel
+                {
+                    Name = reader.GetString(0),
+                    Parameters = reader.IsDBNull(2) ? null : reader.GetDouble(2),
+                    Size = reader.GetInt64(3),
+                    Format = reader.IsDBNull(4) ? null : reader.GetString(4),
+                    Quantization = reader.IsDBNull(5) ? null : reader.GetInt32(5),
+                    Details = details.Count > 0 ? details : null,
+                    DownloadStatus = (ModelDownloadStatus)reader.GetInt32(11)
+                };
+
+                models.Add(model);
+            }
+        }
+
+        return models;
+    }
+}

--- a/avallama/Utilities/DatabaseLock.cs
+++ b/avallama/Utilities/DatabaseLock.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Threading;
+
+namespace avallama.Utilities;
+
+public sealed class DatabaseLock
+{
+    // Singleton instance
+    private static readonly Lazy<DatabaseLock> _instance = new(() => new DatabaseLock());
+    private readonly ReaderWriterLockSlim _lock = new(LockRecursionPolicy.NoRecursion);
+
+    public static DatabaseLock Instance => _instance.Value;
+
+    public IDisposable AcquireReadLock()
+    {
+        _lock.EnterReadLock();
+        return new DisposableAction(() => _lock.ExitReadLock());
+    }
+
+    public IDisposable AcquireWriteLock()
+    {
+        _lock.EnterWriteLock();
+        return new DisposableAction(() => _lock.ExitWriteLock());
+    }
+
+    private sealed class DisposableAction(Action action) : IDisposable
+    {
+        private readonly Action _action = action ?? throw new ArgumentNullException(nameof(action));
+        public void Dispose() => _action();
+    }
+}

--- a/avallama/ViewModels/HomeViewModel.cs
+++ b/avallama/ViewModels/HomeViewModel.cs
@@ -34,7 +34,7 @@ public partial class HomeViewModel : PageViewModel
     private readonly IOllamaService _ollamaService;
     private readonly IDialogService _dialogService;
     private readonly IConfigurationService _configurationService;
-    private readonly IDatabaseService _databaseService;
+    private readonly IConversationService _conversationService;
 
     private readonly TaskCompletionSource<bool> _ollamaServerStarted = new();
     private readonly IMessenger _messenger;
@@ -90,7 +90,7 @@ public partial class HomeViewModel : PageViewModel
         NewMessageText = NewMessageText.Trim();
         var message = new Message(NewMessageText);
         SelectedConversation.AddMessage(message);
-        await _databaseService.InsertMessage(SelectedConversation.ConversationId, message, null, null);
+        await _conversationService.InsertMessage(SelectedConversation.ConversationId, message, null, null);
         NewMessageText = string.Empty;
         if (Conversations.IndexOf(SelectedConversation) != 0)
         {
@@ -107,7 +107,7 @@ public partial class HomeViewModel : PageViewModel
             LocalizationService.GetString("NEW_CONVERSATION"),
             "llama3.2"
         );
-        newConversation.ConversationId = await _databaseService.CreateConversation(newConversation);
+        newConversation.ConversationId = await _conversationService.CreateConversation(newConversation);
         Conversations.Push(newConversation);
         SelectedConversation = newConversation;
     }
@@ -127,7 +127,7 @@ public partial class HomeViewModel : PageViewModel
         var state = GetState(SelectedConversation);
         if (state.MessagesLoaded) return;
 
-        SelectedConversation.Messages = await _databaseService.GetMessagesForConversation(SelectedConversation);
+        SelectedConversation.Messages = await _conversationService.GetMessagesForConversation(SelectedConversation);
         state.MessagesLoaded = true;
     }
 
@@ -164,7 +164,7 @@ public partial class HomeViewModel : PageViewModel
                 }
             }
         }
-        await _databaseService.InsertMessage(SelectedConversation.ConversationId, generatedMessage, CurrentlySelectedModel, generatedMessage.GenerationSpeed);
+        await _conversationService.InsertMessage(SelectedConversation.ConversationId, generatedMessage, CurrentlySelectedModel, generatedMessage.GenerationSpeed);
     }
 
     private async Task RegenerateConversationTitle()
@@ -182,7 +182,7 @@ public partial class HomeViewModel : PageViewModel
             }
 
             SelectedConversation.MessageCountToRegenerateTitle = 0;
-            await _databaseService.UpdateConversationTitle(SelectedConversation);
+            await _conversationService.UpdateConversationTitle(SelectedConversation);
         }
     }
 
@@ -196,7 +196,7 @@ public partial class HomeViewModel : PageViewModel
         IOllamaService ollamaService,
         IDialogService dialogService,
         IConfigurationService configurationService,
-        IDatabaseService databaseService,
+        IConversationService conversationService,
         IMessenger messenger
     )
     {
@@ -206,7 +206,7 @@ public partial class HomeViewModel : PageViewModel
         _dialogService = dialogService;
         _ollamaService = ollamaService;
         _configurationService = configurationService;
-        _databaseService = databaseService;
+        _conversationService = conversationService;
         _messenger = messenger;
         _availableModels = [];
         _currentlySelectedModel = "";
@@ -353,7 +353,7 @@ public partial class HomeViewModel : PageViewModel
 
     private async Task InitializeConversations()
     {
-        _conversations = await _databaseService.GetConversations();
+        _conversations = await _conversationService.GetConversations();
         if (_conversations.Count <= 0)
         {
             await CreateNewConversation();
@@ -361,7 +361,7 @@ public partial class HomeViewModel : PageViewModel
         }
 
         SelectedConversation = _conversations.FirstOrDefault()!;
-        SelectedConversation.Messages = await _databaseService.GetMessagesForConversation(SelectedConversation);
+        SelectedConversation.Messages = await _conversationService.GetMessagesForConversation(SelectedConversation);
         GetState(SelectedConversation).MessagesLoaded = true;
     }
 


### PR DESCRIPTION
Closes https://github.com/4foureyes/avallamaplanning/issues/94

Changes:
- Added new `ModelCacheService` to aid in caching online model info to the database, and reading cached data
- Renamed now conflicting `DatabaseService` to `ConversationService`
- Added shared multi-read single-write database lock
- Fixed links in README pointing to personal fork instead of upstream repository
- Renamed `GetOpenConnectionAsync()` to `InitializeDatabaseAsync()` for more clarity