### PR TITLE
Add conversation delete

### DIFF
--- a/avallama.Tests/Services/ConversationsServiceTests.cs
+++ b/avallama.Tests/Services/ConversationsServiceTests.cs
@@ -284,6 +284,28 @@ public class ConversationServiceTests : IDisposable
         Assert.Equal(longContent, messages[0].Content);
     }
 
+    [Fact]
+    public async Task DeleteConversation_DeletesConversation()
+    {
+        var id = await _conversationService.CreateConversation(
+            new Conversation(Guid.Empty, "Test", new List<Message>()));
+        await _conversationService.DeleteConversation(id);
+        var conversations = await _conversationService.GetConversations();
+        Assert.DoesNotContain(conversations, c => c.ConversationId == id);
+    }
+
+    [Fact]
+    public async Task DeleteConversation_DeletesConversationMessages()
+    {
+        var id = await _conversationService.CreateConversation(
+            new Conversation(Guid.Empty, "Test", new List<Message>()));
+        await _conversationService.InsertMessage(id, new Message("Message 1"), null, null);
+        await _conversationService.DeleteConversation(id);
+        var messages = await _conversationService.GetMessagesForConversation(
+            new Conversation(id, "Test", new List<Message>()));
+        Assert.Empty(messages);
+    }
+
     public void Dispose()
     {
         GC.SuppressFinalize(this);

--- a/avallama/Assets/Localization/Resources.hu.resx
+++ b/avallama/Assets/Localization/Resources.hu.resx
@@ -353,7 +353,7 @@ Licensed under the MIT License. See LICENSE file for details.
         <value>Törlés megerősítése</value>
     </data>
     <data name="CONFIRM_DELETION_DIALOG_DESC" xml:space="preserve">
-        <value>Biztos, hogy törölni szeretnéd a(z) {0} modellt?</value>
+        <value>Biztos, hogy törölni szeretnéd a(z) {0}?</value>
     </data>
     <data name="RESTART_NEEDED_DIALOG_DESC" xml:space="preserve">
         <value>Szeretnéd újraindítani az alkalmazást most?</value>
@@ -399,5 +399,8 @@ Licensed under the MIT License. See LICENSE file for details.
     </data>
     <data name="ERROR_DELETING_MODEL" xml:space="preserve">
         <value>Hiba történt a modell törlése során.</value>
+    </data>
+    <data name="THIS_CONVERSATION" xml:space="preserve">
+        <value>beszélgetést</value>
     </data>
 </root>

--- a/avallama/Assets/Localization/Resources.resx
+++ b/avallama/Assets/Localization/Resources.resx
@@ -407,4 +407,7 @@ Licensed under the MIT License. See LICENSE file for details.
     <data name="ERROR_DELETING_MODEL" xml:space="preserve">
         <value>Error occurred deleting model.</value>
     </data>
+    <data name="THIS_CONVERSATION" xml:space="preserve">
+        <value>this conversation</value>
+    </data>
 </root>

--- a/avallama/Assets/Svg/trash.svg
+++ b/avallama/Assets/Svg/trash.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Copyright (c) Márk Csörgő and Martin Bartos
+Licensed under the MIT License. See LICENSE file for details.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" height="350px" viewBox="0 -960 960 960" width="350px" fill="none">
+    <path d="M280-120q-33 0-56.5-23.5T200-200v-520h-40v-80h200v-40h240v40h200v80h-40v520q0 33-23.5 56.5T680-120H280Zm400-600H280v520h400v-520ZM360-280h80v-360h-80v360Zm160 0h80v-360h-80v360ZM280-720v520-520Z"/>
+</svg>

--- a/avallama/Views/HomeView.axaml
+++ b/avallama/Views/HomeView.axaml
@@ -114,6 +114,19 @@ Licensed under the MIT License. See LICENSE file for details.
                       IsEnabled="{Binding IsModelsDropdownEnabled}" Name="ModelsComboBox"/>
         </StackPanel>
 
+        <Button Grid.Row="0" Grid.Column="3"
+                Classes="svgButton"
+                HorizontalAlignment="Right"
+                VerticalAlignment="Top"
+                Margin="0,10,10,0"
+                Cursor="Hand"
+                Command="{Binding DeleteConversationCommand}">
+            <controls:DynamicSvg
+                Path="/Assets/Svg/trash.svg"
+                Width="30"
+                FillColor="{DynamicResource Primary}" />
+        </Button>
+
         <!-- Tájékoztató szövegek -->
         <StackPanel Grid.Column="1" Grid.ColumnSpan="3" Grid.Row="1" Orientation="Vertical" Margin="18,10,18,0"
                     HorizontalAlignment="Stretch" VerticalAlignment="Center" Spacing="6"


### PR DESCRIPTION
Closes https://github.com/4foureyes/avallamaplanning/issues/75

Changes:
- Added a delete button in the top-right corner
- Clicking on this button first displays a confirmation dialog, then upon confirmation deletes the conversation from the UI, and in the database
- The `ON DELETE CASCADE` clause in the db schema ensures all associated messages are also deleted from the database