### PR TITLE
Fix Windows installer issues

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,12 @@ jobs:
         with:
           dotnet-version: '9.x'
 
+      - name: Set version var
+        run: |
+          $version = $env:GITHUB_REF_NAME -replace '^v', ''
+          "VERSION=$version" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+
       - name: Restore & Publish
         run: dotnet publish avallama/avallama.csproj -c Release -r win-x64 --self-contained true -o win-dist /p:PublishSingleFile=true
 
@@ -38,17 +44,16 @@ jobs:
 
       - name: Build Installer
         run: |
-          $VERSION = "${{ github.ref_name }}"
-          $VERSION = $VERSION.Substring(1)
           & "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" `
-            /DAppVersion="${VERSION}" `
+            /DAppVersion="${env:VERSION}" `
             scripts\installer.iss
+
 
       - name: Upload .exe Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: AvallamaSetup.exe
-          path: scripts\AvallamaSetup.exe
+          name: avallama-setup-${{ env.VERSION }}.exe
+          path: scripts\avallama-setup-${{ env.VERSION }}.exe
 
   build-debian:
     name: Debian Package (.deb)
@@ -73,7 +78,7 @@ jobs:
       - name: Upload Debian Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: linux-packages
+          name: debian-package
           path: |
             avallama_${{ env.VERSION }}_amd64.deb
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ sudo pacman -Rns avallama
 
 The Windows installer is **not signed with a trusted code-signing certificate**, so Windows SmartScreen may prevent it from running. If you wish to circumvent this, click `More info -> Run anyway`.
 
-1. Download the latest version of AvallamaSetup.exe from the [releases](https://github.com/4foureyes/avallama/releases) page.
+1. Download the latest Windows installer from the [releases](https://github.com/4foureyes/avallama/releases) page, e.g. `avallama-setup-0.2.0.exe`.
 2. Open the installer and go through the setup steps.
 3. Once installed, you can run the application from the Start Menu.
 

--- a/scripts/installer.iss
+++ b/scripts/installer.iss
@@ -1,14 +1,18 @@
+#ifndef AppVersion
 #define AppVersion "0.0.0"
+#endif
 
 [Setup]
-AppName=Avallama
+AppName=avallama
 AppVersion={#AppVersion}
-DefaultDirName={localappdata}\Avallama
+AppVerName=avallama
+DefaultDirName={localappdata}\avallama
 DefaultGroupName=4foureyes
-UninstallDisplayIcon={app}\Avallama.exe
+UninstallDisplayIcon={app}\avallama.exe
 OutputDir=.
-OutputBaseFilename=AvallamaSetup
+OutputBaseFilename=avallama-setup-{#AppVersion}
 PrivilegesRequired=lowest
+VersionInfoVersion={#AppVersion}
 
 [Code]
 var
@@ -28,50 +32,69 @@ end;
 
 procedure CreateOllamaWarningPage(Page: TWizardPage);
 var
-  Label1, Label2, Label3, Label4: TLabel;
-  Button1: TButton;
+  TitleLabel, InfoLabel1, InfoLabel2, InfoLabel3, InfoLabel4: TLabel;
+  DownloadButton: TButton;
 begin
-  Label1 := TLabel.Create(Page);
-  Label1.Parent := Page.Surface;
-  Label1.Caption := 'No installation of Ollama was found on your system.';
-  Label1.Top := 20;
-  Label1.Left := 10;
-  Label1.AutoSize := True;
-  
-  Label2 := TLabel.Create(Page);
-  Label2.Parent := Page.Surface;
-  Label2.Caption := 'An installation of Ollama is required for Avallama to work properly.';
-  Label2.Top := 40;
-  Label2.Left := 10;
-  Label2.AutoSize := True;
-  
-  Label3 := TLabel.Create(Page);
-  Label3.Parent := Page.Surface;
-  Label3.Caption := 'Click the button below to open the Ollama download page in your browser.';
-  Label3.Top := 60;
-  Label3.Left := 10;
-  Label3.AutoSize := True;
-  
-  Label4 := TLabel.Create(Page);
-  Label4.Parent := Page.Surface;
-  Label4.Caption := 'If Ollama has been installed, please continute with the setup.';
-  Label4.Top := 80;
-  Label4.Left := 10;
-  Label4.AutoSize := True;
+  { Title }
+  TitleLabel := TLabel.Create(Page);
+  TitleLabel.Parent := Page.Surface;
+  TitleLabel.Caption := 'No Ollama install was found on your machine.';
+  TitleLabel.Font.Style := [fsBold];
+  TitleLabel.Font.Size := 12;
+  TitleLabel.Left := 10;
+  TitleLabel.Top := 10;
+  TitleLabel.AutoSize := True;
 
-  Button1 := TButton.Create(Page);
-  Button1.Parent := Page.Surface;
-  Button1.Caption := 'Open';
-  Button1.Top := Label4.Top + Label4.Height + 10;
-  Button1.Left := 10;
-  Button1.OnClick := @Button1Click;
+  { Line 1 }
+  InfoLabel1 := TLabel.Create(Page);
+  InfoLabel1.Parent := Page.Surface;
+  InfoLabel1.Caption :=
+    'Avallama can be used with an existing Ollama instance on your network.';
+  InfoLabel1.Left := 10;
+  InfoLabel1.Top := TitleLabel.Top + TitleLabel.Height + 10;
+  InfoLabel1.Width := Page.SurfaceWidth - 20;
+
+  { Line 2 }
+  InfoLabel2 := TLabel.Create(Page);
+  InfoLabel2.Parent := Page.Surface;
+  InfoLabel2.Caption :=
+    'In this case, you may safely continue with the installation.';
+  InfoLabel2.Left := 10;
+  InfoLabel2.Top := InfoLabel1.Top + InfoLabel1.Height + 10;
+  InfoLabel2.Width := Page.SurfaceWidth - 20;
+
+  { Line 3 }
+  InfoLabel3 := TLabel.Create(Page);
+  InfoLabel3.Parent := Page.Surface;
+  InfoLabel3.Caption :=
+    'Otherwise, please install Ollama before continuing.';
+  InfoLabel3.Left := 10;
+  InfoLabel3.Top := InfoLabel2.Top + InfoLabel2.Height + 10;
+  InfoLabel3.Width := Page.SurfaceWidth - 20;
+
+  { Line 4 }
+  InfoLabel4 := TLabel.Create(Page);
+  InfoLabel4.Parent := Page.Surface;
+  InfoLabel4.Caption :=
+    'Click the button below to open the Ollama download page.';
+  InfoLabel4.Left := 10;
+  InfoLabel4.Top := InfoLabel3.Top + InfoLabel3.Height + 10;
+  InfoLabel4.Width := Page.SurfaceWidth - 20;
+
+  { Download button }
+  DownloadButton := TButton.Create(Page);
+  DownloadButton.Parent := Page.Surface;
+  DownloadButton.Caption := 'Open';
+  DownloadButton.Top := InfoLabel4.Top + InfoLabel4.Height + 15;
+  DownloadButton.Left := 10;
+  DownloadButton.OnClick := @Button1Click;
 end;
 
 procedure InitializeWizard();
 begin
   if not IsOllamaInstalled() then
   begin
-    MyPage := CreateCustomPage(wpWelcome, 'Warning', 'Avallama requires Ollama to be installed.');
+    MyPage := CreateCustomPage(wpWelcome, 'Warning', 'No Ollama installation found');
     CreateOllamaWarningPage(MyPage);
   end;
 end;
@@ -80,8 +103,11 @@ end;
 Source: "{#SourcePath}\..\win-dist\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
 
 [Icons]
-Name: "{group}\Avallama"; Filename: "{app}\Avallama.exe"; IconFilename: "{app}\Avallama.exe"
-Name: "{group}\Uninstall Avallama"; Filename: "{uninstallexe}"
+Name: "{group}\avallama"; Filename: "{app}\avallama.exe"; IconFilename: "{app}\avallama.exe"
+Name: "{group}\Uninstall avallama"; Filename: "{uninstallexe}"
 
 [Run]
-Filename: "{app}\Avallama.exe"; Description: "Launch application"; Flags: nowait postinstall
+Filename: "{app}\avallama.exe"; Description: "Launch avallama"; Flags: nowait postinstall
+
+[UninstallDelete]
+Type: filesandordirs; Name: "{userappdata}\avallama"


### PR DESCRIPTION
Fixes https://github.com/4foureyes/avallamaplanning/issues/93

Changes:
- Windows installer now installs the application as "avallama" instead of "Avallama", and this is how it shows up in the Start menu.
- Redesigned the warning page a little and altered the phrasing to include information about being able to use the application with an Ollama instance on the network
- Windows installer is now created under the name "avallama-setup-[TAG].exe" instead of "AvallamaSetup.exe" to be consistent with other release artifacts
- Windows Uninstaller now deletes files in `\AppData\Roaming\avallama` when uninstalling