### PR TITLE
Fix Arch build step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,6 +91,7 @@ jobs:
     steps:
       - name: Install base build tools and .NET
         run: |
+          pacman -Syu --noconfirm
           pacman -Sy --noconfirm base-devel git curl unzip icu dotnet-sdk dotnet-runtime fontconfig freetype2 libx11 libxrender libxcb mesa libpng zlib
           dotnet --version
 


### PR DESCRIPTION
Fixes https://github.com/4foureyes/avallamaplanning/issues/99

Just added a step to perform a system upgrade before everything else so that any out-of-date dependencies from the docker image get upgraded. This only results in like +2 seconds of Actions time. Hopefully the arch:latest docker image never gets too out of sync to cause a spike in Actions time because of the full system upgrade, but if it does it's rather easy to host our own up-to-date arch image.