### PR TITLE
Fix conversation title generation bug

### DIFF
--- a/avallama.Tests/ViewModels/HomeViewModelTests.cs
+++ b/avallama.Tests/ViewModels/HomeViewModelTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Márk Csörgő and Martin Bartos
 // Licensed under the MIT License. See LICENSE file for details.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Threading.Tasks;
@@ -83,5 +84,130 @@ public class HomeViewModelTests(TestServicesFixture fixture) : IClassFixture<Tes
 
         Assert.Empty(vm.AvailableModels);
         Assert.False(vm.IsModelsDropdownEnabled);
+    }
+
+    [Fact]
+    public async Task TitleRegenerates_WhenFirstMessageExchangeOccurs()
+    {
+        fixture.OllamaMock.Reset();
+        fixture.DbMock.Reset();
+
+        var conv = new Conversation("A", string.Empty) { ConversationId = Guid.NewGuid() };
+
+        fixture.OllamaMock
+            .Setup(o => o.GenerateMessage(It.IsAny<List<Message>>(), It.IsAny<string>()))
+            .Returns(MainStreamAsync());
+
+        var vm = new HomeViewModel(
+            fixture.OllamaMock.Object,
+            fixture.DialogMock.Object,
+            fixture.ConfigMock.Object,
+            fixture.DbMock.Object,
+            fixture.MessengerMock.Object
+        );
+
+        await vm.InitializeAsync();
+
+        vm.SelectedConversation = conv;
+        vm.NewMessageText = "hello";
+
+        await vm.SendMessageCommand.ExecuteAsync(null);
+
+        fixture.DbMock.Verify(
+            db => db.UpdateConversationTitle(It.Is<Conversation>(c => c.ConversationId == conv.ConversationId)),
+            Times.AtLeastOnce);
+    }
+
+
+    [Fact]
+    public async Task TitleGeneration_WhenUserSwitchesConversation_UpdatesRightConversation()
+    {
+        fixture.OllamaMock.Reset();
+        fixture.DbMock.Reset();
+
+        var convA = new Conversation("A", string.Empty) { ConversationId = Guid.NewGuid() };
+        var convB = new Conversation("B", string.Empty) { ConversationId = Guid.NewGuid() };
+
+        fixture.DbMock.Setup(db => db.GetConversations()).ReturnsAsync([convA, convB]);
+        fixture.DbMock.Setup(db => db.GetMessagesForConversation(It.IsAny<Conversation>())).ReturnsAsync([]);
+        fixture.DbMock.Setup(db => db.InsertMessage(It.IsAny<Guid>(), It.IsAny<Message>(), It.IsAny<string?>(), It.IsAny<double?>()))
+            .Returns(Task.CompletedTask);
+
+        var allowTitleToFinish = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        fixture.OllamaMock
+            .Setup(o => o.GenerateMessage(It.IsAny<List<Message>>(), It.IsAny<string>()))
+            .Returns((List<Message> history, string _) =>
+            {
+                var isTitleRequest =
+                    history.Count > 0 &&
+                    history[^1].Content.Contains(
+                        "Generate only a single short title",
+                        StringComparison.Ordinal);
+
+                return isTitleRequest
+                    ? TitleStreamAsync(allowTitleToFinish.Task)
+                    : MainStreamAsync();
+            });
+
+        var updatedConversationIds = new List<Guid>();
+        fixture.DbMock
+            .Setup(db => db.UpdateConversationTitle(It.IsAny<Conversation>()))
+            .Callback<Conversation>(c => updatedConversationIds.Add(c.ConversationId))
+            .ReturnsAsync(true);
+
+        var vm = new HomeViewModel(
+            fixture.OllamaMock.Object,
+            fixture.DialogMock.Object,
+            fixture.ConfigMock.Object,
+            fixture.DbMock.Object,
+            fixture.MessengerMock.Object
+        );
+
+        await vm.InitializeAsync();
+
+        vm.SelectedConversation = convA;
+
+        vm.NewMessageText = "hello";
+
+        var generateTask = vm.SendMessageCommand.ExecuteAsync(null);
+
+        vm.SelectedConversation = convB;
+
+        allowTitleToFinish.SetResult();
+        await generateTask;
+
+        Assert.Contains(convA.ConversationId, updatedConversationIds);
+        Assert.DoesNotContain(convB.ConversationId, updatedConversationIds);
+
+        fixture.DbMock.Verify(
+            db => db.UpdateConversationTitle(It.Is<Conversation>(c => c.ConversationId == convA.ConversationId)),
+            Times.AtLeastOnce);
+
+        fixture.DbMock.Verify(
+            db => db.UpdateConversationTitle(It.Is<Conversation>(c => c.ConversationId == convB.ConversationId)),
+            Times.Never);
+    }
+
+    private static async IAsyncEnumerable<OllamaResponse> MainStreamAsync()
+    {
+        yield return new OllamaResponse
+        {
+            Message = new MessageContent { Content = "assistant chunk" },
+            EvalCount = 10,
+            EvalDuration = 1_000_000_000
+        };
+
+        await Task.CompletedTask;
+    }
+
+    private static async IAsyncEnumerable<OllamaResponse> TitleStreamAsync(Task gate)
+    {
+        yield return new OllamaResponse
+        {
+            Message = new MessageContent { Content = "Right conversation title" }
+        };
+
+        await gate.ConfigureAwait(false);
     }
 }

--- a/avallama/Models/Conversation.cs
+++ b/avallama/Models/Conversation.cs
@@ -12,7 +12,6 @@ public class Conversation : ObservableObject
 {
     private string _title = string.Empty;
     private string _model = string.Empty;
-    private int _messageCountToRegenerateTitle;
     private ObservableCollection<Message> _messages = [];
     private Guid _conversationId = Guid.Empty;
 
@@ -34,23 +33,16 @@ public class Conversation : ObservableObject
         set => SetProperty(ref _messages, value);
     }
 
-    public int MessageCountToRegenerateTitle
-    {
-        get => _messageCountToRegenerateTitle;
-        set => SetProperty(ref _messageCountToRegenerateTitle, value);
-    }
-
     public Guid ConversationId
     {
         get => _conversationId;
         set => SetProperty(ref _conversationId, value);
     }
-    
+
     public Conversation(string title, string model)
     {
         Title = title;
         Model = model;
-        MessageCountToRegenerateTitle = 0;
     }
 
     public Conversation(Guid guid, string title, IList<Message> messages)
@@ -58,8 +50,7 @@ public class Conversation : ObservableObject
         ConversationId = guid;
         Title = title;
         Messages = new ObservableCollection<Message>(messages);
-        MessageCountToRegenerateTitle = 0;
     }
-    
+
     public void AddMessage(Message message) => Messages.Add(message);
 }


### PR DESCRIPTION
Fixes https://github.com/4foureyes/avallamaplanning/issues/69

Really it just passes the `SelectedConversation` as an object to the methods instead of using the data member which is volatile. 

I also reworked the title generation logic to generate a title after the first message exchange (2 messages), and then every 3 message exchanges (6 messages). I also removed the `MessageCountToRegenerate` property of the `Conversation` class as it became redundant, since the new message regeneration logic just calculates using the `Messages.Count` property of the `Conversation`

This introduced in interesting "bug" however, when prompting gpt-oss:120b with "hey how are you", it generated a title that was: "Chat Greeting and Request for Title" lmao. I guess this could also be fixed when reworking the whole title generation function.

I also discovered a new bug, where when clicking away from the conversation when the message only contains the "Generating message..." text, then it entirely disappears and only reappears if it is saved to the db and the app is reloaded. I'll create an issue for this.