### PR TITLE
Add disk space check to model download operation

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -50,6 +50,7 @@ jobs:
           dotnet test avallama.sln
           --configuration Release
           --no-build
+          --settings avallama.Tests/runsettings.runsettings
           --collect:"XPlat Code Coverage"
           --logger "trx;LogFileName=test-results.trx"
           --logger "console;verbosity=detailed"

--- a/avallama.Tests/Utilities/DiskManagerTests.cs
+++ b/avallama.Tests/Utilities/DiskManagerTests.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.IO;
+using avallama.Utilities;
+using Xunit;
+
+namespace avallama.Tests.Utilities;
+
+public class DiskManagerTests
+{
+    [Fact]
+    public void IsEnoughDiskSpaceAvailable_WhenRequiredBytesIsZero_ReturnsTrueIfReserveFitsOnThisMachine()
+    {
+        // Arrange (compute expected based on the same rules DiskManager uses)
+        const long minReserveBytes = 10L * 1024 * 1024 * 1024;
+        const double reserveFraction = 0.02;
+
+        var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+        var root = Directory.GetDirectoryRoot(appData);
+        var drive = new DriveInfo(root);
+
+        if (!drive.IsReady)
+        {
+            // DiskManager returns false when the drive isn't ready; avoid flakiness on weird environments.
+            Assert.False(DiskManager.IsEnoughDiskSpaceAvailable(0));
+            return;
+        }
+
+        var reserve = Math.Max(minReserveBytes, (long)(drive.TotalSize * reserveFraction));
+        var expected = drive.AvailableFreeSpace >= reserve;
+
+        var result = DiskManager.IsEnoughDiskSpaceAvailable(0);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void IsEnoughDiskSpaceAvailable_WhenRequiredBytesIsHuge_ReturnsFalse()
+    {
+        // Using a very large value makes this deterministic on any normal machine.
+        // long.MaxValue / 2 equates to about 4.5 exabytes, which is way beyond any reasonable disk size.
+        var result = DiskManager.IsEnoughDiskSpaceAvailable(long.MaxValue / 2);
+
+        Assert.False(result);
+    }
+}

--- a/avallama.Tests/runsettings.runsettings
+++ b/avallama.Tests/runsettings.runsettings
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <RunConfiguration>
+    <DisableParallelization>true</DisableParallelization>
+  </RunConfiguration>
+</RunSettings>

--- a/avallama/Assets/Localization/Resources.hu.resx
+++ b/avallama/Assets/Localization/Resources.hu.resx
@@ -463,4 +463,7 @@ Licensed under the MIT License. See LICENSE file for details.
     <data name="LOST_INTERNET_WARNING" xml:space="preserve">
         <value>Az internetkapcsolat megszakadt. Kérlek próbáld meg újra.</value>
     </data>
+    <data name="NO_DISK_SPACE_MODEL_DOWNLOAD_WARNING" xml:space="preserve">
+        <value>Nincs elegendő tárhely ezen a meghajtón a modell letöltéséhez.</value>
+    </data>
 </root>

--- a/avallama/Assets/Localization/Resources.resx
+++ b/avallama/Assets/Localization/Resources.resx
@@ -470,4 +470,7 @@ Licensed under the MIT License. See LICENSE file for details.
     <data name="LOST_INTERNET_WARNING" xml:space="preserve">
         <value>Internet connection lost. Please try again.</value>
     </data>
+    <data name="NO_DISK_SPACE_MODEL_DOWNLOAD_WARNING" xml:space="preserve">
+        <value>There is not enough storage space on the disk to download this model.</value>
+    </data>
 </root>

--- a/avallama/Utilities/DiskManager.cs
+++ b/avallama/Utilities/DiskManager.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.IO;
+
+namespace avallama.Utilities;
+
+/// <summary>
+/// Utility class for managing disk related operations.
+/// </summary>
+public static class DiskManager
+{
+    // TODO: In the future when a custom storage location for models is implemented, this needs to be revisited.
+
+    /// <summary>
+    /// Checks if there is enough disk space available on the drive where the application data folder is located.
+    /// This is useful for ensuring that there is sufficient space before performing operations such as downloading a model.
+    /// It reserves a minimum of 10GB or 2% of the total disk size, whichever is larger, to prevent the disk from being completely filled.
+    /// </summary>
+    /// <param name="requiredBytes"> The amount of bytes an operation would need to be free on the disk </param>
+    /// <returns> True if there is enough space (more than 10 GB or 2% of disk space + required bytes), false otherwise </returns>
+    public static bool IsEnoughDiskSpaceAvailable(long requiredBytes)
+    {
+        const long minReserveBytes = 10L * 1024 * 1024 * 1024;
+        const double reserveFraction = 0.02;
+
+        var path = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+        var rootDir = Directory.GetDirectoryRoot(path);
+        var driveInfo = new DriveInfo(rootDir);
+        try
+        {
+            if (driveInfo.IsReady)
+            {
+                var percentReserveBytes = (long)(driveInfo.TotalSize * reserveFraction);
+                var reserveBytes = Math.Max(minReserveBytes, percentReserveBytes);
+                return driveInfo.AvailableFreeSpace >= requiredBytes + reserveBytes;
+            }
+        }
+        catch (IOException ex)
+        {
+            // TODO: InterruptService
+        }
+
+        return false;
+    }
+}

--- a/avallama/Utilities/Network/NetworkManager.cs
+++ b/avallama/Utilities/Network/NetworkManager.cs
@@ -15,6 +15,7 @@ public interface INetworkManager
 {
     /// <summary>
     /// Checks if the internet is available by getting the header for 1.1.1.1.
+    /// <returns> True if internet is available (Header arrives in less than 1 second), False otherwise </returns>
     /// </summary>
     public Task<bool> IsInternetAvailableAsync();
 }
@@ -29,10 +30,7 @@ public class NetworkManager(IHttpClientFactory httpClientFactory) : INetworkMana
     /// </summary>
     private readonly HttpClient _httpClient = httpClientFactory.CreateClient("OllamaCheckHttpClient");
 
-    /// <summary>
-    /// Checks if the internet is available by getting the header for 1.1.1.1.
-    /// <returns> True if internet is available (Header arrives in less than 1 second), False otherwise </returns>
-    /// </summary>
+    /// <inheritdoc/>
     public async Task<bool> IsInternetAvailableAsync()
     {
         try


### PR DESCRIPTION
Closes https://github.com/4foureyes/avallamaplanning/issues/106

Changes:
- Implemented a simple static method to check if enough space is available on the disk
- This can be called by providing the amount of bytes that would be needed by a specific operation (e.g. downloading model)
- This calculates a reserve amount, which is `max(2% of total disk space, 10GB)` to avoid filling up the entire disk completely
- Added tests for this method
- Configured tests to run non-parallel to avoid weird issues in CI
- Also cleaned up docs for `NetworkManager`