### PR TITLE
Remove cloud, latest and image models from scraping + Add update checking

### DIFF
--- a/avallama.Tests/Fixtures/TestServicesFixture.cs
+++ b/avallama.Tests/Fixtures/TestServicesFixture.cs
@@ -22,4 +22,5 @@ public class TestServicesFixture
     public Mock<IOllamaScraperService> ScraperMock { get; } = new();
     public Mock<IModelDownloadQueueService> DownloadQueueMock { get; } = new();
     public Mock<INetworkManager> NetworkManagerMock { get; } = new();
+    public Mock<IUpdateService> UpdateMock { get; } = new();
 }

--- a/avallama.Tests/Services/OllamaScraperServiceTests.cs
+++ b/avallama.Tests/Services/OllamaScraperServiceTests.cs
@@ -165,7 +165,8 @@ public class OllamaScraperServiceTests
             Assert.NotNull(family.Labels);
         });
 
-        Assert.Equal(6, modelsList.Count);
+        // excluding cloud and latest models
+        Assert.Equal(2, modelsList.Count);
 
         Assert.All(modelsList, model =>
         {
@@ -185,12 +186,12 @@ public class OllamaScraperServiceTests
         Assert.Contains(result.Families, f => f.Name == "gpt-oss");
         Assert.Contains(result.Families, f => f.Name == "qwen3-vl");
 
-        Assert.Contains(modelsList, m => m.Name == "gpt-oss:latest");
+        Assert.DoesNotContain(modelsList, m => m.Name == "gpt-oss:latest");
         Assert.Contains(modelsList, m => m.Name == "gpt-oss:20b");
         Assert.Contains(modelsList, m => m.Name == "gpt-oss:120b");
-        Assert.Contains(modelsList, m => m.Name == "qwen3-vl:latest");
-        Assert.Contains(modelsList, m => m.Name == "qwen3-vl:235b-cloud");
-        Assert.Contains(modelsList, m => m.Name == "qwen3-vl:235b-instruct-cloud");
+        Assert.DoesNotContain(modelsList, m => m.Name == "qwen3-vl:latest");
+        Assert.DoesNotContain(modelsList, m => m.Name == "qwen3-vl:235b-cloud");
+        Assert.DoesNotContain(modelsList, m => m.Name == "qwen3-vl:235b-instruct-cloud");
     }
 
     [Fact]
@@ -240,11 +241,7 @@ public class OllamaScraperServiceTests
         await foreach (var m in result.Models) models.Add(m);
 
         Assert.Equal(2, result.Families.Count);
-        Assert.Equal(3, models.Count);
-
-        Assert.Contains(models, m => m.Name == "qwen3-vl:latest");
-        Assert.Contains(models, m => m.Name == "qwen3-vl:235b-cloud");
-        Assert.Contains(models, m => m.Name == "qwen3-vl:235b-instruct-cloud");
+        Assert.Empty(models);
     }
 
     [Fact]

--- a/avallama.Tests/Services/UpdateServiceTests.cs
+++ b/avallama.Tests/Services/UpdateServiceTests.cs
@@ -1,0 +1,113 @@
+﻿using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using Moq.Protected;
+using avallama.Services;
+using avallama.Utilities.Network;
+using Xunit;
+
+namespace avallama.Tests.Services;
+
+public class UpdateServiceTests
+{
+    private readonly Mock<INetworkManager> _networkManagerMock;
+    private readonly Mock<HttpMessageHandler> _httpMessageHandlerMock;
+    private readonly HttpClient _httpClient;
+
+    public UpdateServiceTests()
+    {
+        _networkManagerMock = new Mock<INetworkManager>();
+        _httpMessageHandlerMock = new Mock<HttpMessageHandler>();
+        _httpClient = new HttpClient(_httpMessageHandlerMock.Object);
+    }
+
+    private UpdateService CreateService() => new(_httpClient, _networkManagerMock.Object);
+
+    private void SetupHttpResponse(HttpStatusCode statusCode, string content)
+    {
+        _httpMessageHandlerMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = statusCode,
+                Content = new StringContent(content)
+            });
+    }
+
+    [Fact]
+    public async Task IsUpdateAvailableAsync_NoInternet_ReturnsFalse()
+    {
+        _networkManagerMock.Setup(x => x.IsInternetAvailableAsync()).ReturnsAsync(false);
+        var service = CreateService();
+
+        var result = await service.IsUpdateAvailableAsync();
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task IsUpdateAvailableAsync_HttpRequestFails_ReturnsFalse()
+    {
+        _networkManagerMock.Setup(x => x.IsInternetAvailableAsync()).ReturnsAsync(true);
+        SetupHttpResponse(HttpStatusCode.InternalServerError, "");
+        var service = CreateService();
+
+        var result = await service.IsUpdateAvailableAsync();
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task IsUpdateAvailableAsync_NewVersionAvailable_ReturnsTrue()
+    {
+        _networkManagerMock.Setup(x => x.IsInternetAvailableAsync()).ReturnsAsync(true);
+        var json = JsonSerializer.Serialize(new { tag_name = "v99.0.0" });
+        SetupHttpResponse(HttpStatusCode.OK, json);
+        var service = CreateService();
+
+        var result = await service.IsUpdateAvailableAsync();
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task IsUpdateAvailableAsync_SameVersion_ReturnsFalse()
+    {
+        _networkManagerMock.Setup(x => x.IsInternetAvailableAsync()).ReturnsAsync(true);
+        const string currentVersion = App.Version;
+        var json = JsonSerializer.Serialize(new { tag_name = currentVersion });
+        SetupHttpResponse(HttpStatusCode.OK, json);
+        var service = CreateService();
+
+        var result = await service.IsUpdateAvailableAsync();
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task IsUpdateAvailableAsync_CallsCorrectGitHubEndpoint()
+    {
+        _networkManagerMock.Setup(x => x.IsInternetAvailableAsync()).ReturnsAsync(true);
+        var json = JsonSerializer.Serialize(new { tag_name = "v1.0.0" });
+        SetupHttpResponse(HttpStatusCode.OK, json);
+        var service = CreateService();
+
+        await service.IsUpdateAvailableAsync();
+
+        _httpMessageHandlerMock
+            .Protected()
+            .Verify(
+                "SendAsync",
+                Times.Once(),
+                ItExpr.Is<HttpRequestMessage>(req =>
+                    req.RequestUri!.ToString() == "https://api.github.com/repos/4foureyes/avallama/releases/latest"),
+                ItExpr.IsAny<CancellationToken>());
+    }
+}

--- a/avallama.Tests/ViewModels/HomeViewModelTests.cs
+++ b/avallama.Tests/ViewModels/HomeViewModelTests.cs
@@ -43,13 +43,7 @@ public class HomeViewModelTests(TestServicesFixture fixture) : IClassFixture<Tes
 
         SetupMock();
 
-        var vm = new HomeViewModel(
-            fixture.OllamaMock.Object,
-            fixture.DialogMock.Object,
-            fixture.ConfigMock.Object,
-            fixture.DbMock.Object,
-            fixture.MessengerMock.Object
-        );
+        var vm = CreateViewModel();
 
         var availableModels = new ObservableCollection<string>
         {
@@ -74,13 +68,7 @@ public class HomeViewModelTests(TestServicesFixture fixture) : IClassFixture<Tes
 
         SetupMock();
 
-        var vm = new HomeViewModel(
-            fixture.OllamaMock.Object,
-            fixture.DialogMock.Object,
-            fixture.ConfigMock.Object,
-            fixture.DbMock.Object,
-            fixture.MessengerMock.Object
-        );
+        var vm = CreateViewModel();
 
         await vm.InitializeAsync();
 
@@ -100,13 +88,7 @@ public class HomeViewModelTests(TestServicesFixture fixture) : IClassFixture<Tes
             .Setup(o => o.GenerateMessage(It.IsAny<List<Message>>(), It.IsAny<string>()))
             .Returns(MainStreamAsync());
 
-        var vm = new HomeViewModel(
-            fixture.OllamaMock.Object,
-            fixture.DialogMock.Object,
-            fixture.ConfigMock.Object,
-            fixture.DbMock.Object,
-            fixture.MessengerMock.Object
-        );
+        var vm = CreateViewModel();
 
         await vm.InitializeAsync();
 
@@ -159,13 +141,7 @@ public class HomeViewModelTests(TestServicesFixture fixture) : IClassFixture<Tes
             .Callback<Conversation>(c => updatedConversationIds.Add(c.ConversationId))
             .ReturnsAsync(true);
 
-        var vm = new HomeViewModel(
-            fixture.OllamaMock.Object,
-            fixture.DialogMock.Object,
-            fixture.ConfigMock.Object,
-            fixture.DbMock.Object,
-            fixture.MessengerMock.Object
-        );
+        var vm = CreateViewModel();
 
         await vm.InitializeAsync();
 
@@ -212,5 +188,17 @@ public class HomeViewModelTests(TestServicesFixture fixture) : IClassFixture<Tes
         };
 
         await gate.ConfigureAwait(false);
+    }
+
+    private HomeViewModel CreateViewModel()
+    {
+        return new HomeViewModel(
+            fixture.OllamaMock.Object,
+            fixture.DialogMock.Object,
+            fixture.ConfigMock.Object,
+            fixture.DbMock.Object,
+            fixture.UpdateMock.Object,
+            fixture.MessengerMock.Object
+        );
     }
 }

--- a/avallama.Tests/Views/HomeViewTests.cs
+++ b/avallama.Tests/Views/HomeViewTests.cs
@@ -68,6 +68,7 @@ public class HomeViewTests : IClassFixture<TestServicesFixture>
             _fixture.DialogMock.Object,
             _fixture.ConfigMock.Object,
             _fixture.DbMock.Object,
+            _fixture.UpdateMock.Object,
             _fixture.MessengerMock.Object
         );
     }

--- a/avallama/App.axaml.cs
+++ b/avallama/App.axaml.cs
@@ -27,6 +27,7 @@ public partial class App : Application
     private DialogService? _dialogService;
     private DatabaseInitService? _databaseInitService;
     public static SqliteConnection SharedDbConnection { get; private set; } = null!;
+    public const string Version = "v0.3.0";
 
     public override void Initialize()
     {
@@ -136,7 +137,7 @@ public partial class App : Application
     {
         // this is for later for some fancy dialog
         _dialogService?.ShowInfoDialog(
-            "Avallama - " + LocalizationService.GetString("VERSION")
+            "Avallama - " + Version
                           + "\n\nCopyright (c) " + LocalizationService.GetString("DEVELOPER_NAMES")
                           + "\n\n" + LocalizationService.GetString("LICENSE_DETAILS")
                           + "\n\n" + LocalizationService.GetString("FROM_ORG") + " (github.com/4foureyes/avallama)"

--- a/avallama/Assets/Localization/Resources.hu.resx
+++ b/avallama/Assets/Localization/Resources.hu.resx
@@ -50,9 +50,6 @@ Licensed under the MIT License. See LICENSE file for details.
     <data name="LOW_VRAM_WARNING" xml:space="preserve">
         <value>Ez a modell nem fut optimálisan a rendszereden alacsony elérhető VRAM miatt.</value>
     </data>
-    <data name="VERSION" xml:space="preserve">
-        <value>v0.2.0</value>
-    </data>
     <data name="OLLAMA_STARTED" xml:space="preserve">
         <value>Az Ollama sikeresen elindult</value>
     </data>
@@ -511,5 +508,20 @@ Licensed under the MIT License. See LICENSE file for details.
     </data>
     <data name="SCRAPE_ASK_DIALOG_INFO" xml:space="preserve">
         <value>A modellkönyvtárat később bármikor frissítheted a Beállításokban.</value>
+    </data>
+    <data name="UPDATE_CHECK_SETTING" xml:space="preserve">
+        <value>Frissítés észlelés</value>
+    </data>
+    <data name="UPDATE_CHECK_SETTING_DESC" xml:space="preserve">
+        <value>Bekapcsolt állapotban az applikáció indulásakor automatikusan észleli, ha elérhető egy újabb verzió</value>
+    </data>
+    <data name="UPDATE_AVAILABLE" xml:space="preserve">
+        <value>Frissítés elérhető</value>
+    </data>
+    <data name="UPDATE_AVAILABLE_DESC" xml:space="preserve">
+        <value>A frissítéshez töltsd le a legújabb releaset a GitHub oldalunkról.</value>
+    </data>
+    <data name="OPEN_GITHUB" xml:space="preserve">
+        <value>GitHub Megnyitása</value>
     </data>
 </root>

--- a/avallama/Assets/Localization/Resources.resx
+++ b/avallama/Assets/Localization/Resources.resx
@@ -58,9 +58,6 @@ Licensed under the MIT License. See LICENSE file for details.
     <data name="LOW_VRAM_WARNING" xml:space="preserve">
         <value>This model is not running optimally on your system due to low avaliable VRAM</value>
     </data>
-    <data name="VERSION" xml:space="preserve">
-        <value>v0.3.0</value>
-    </data>
     <data name="OLLAMA_STARTED" xml:space="preserve">
         <value>Ollama has been successfully started</value>
     </data>
@@ -519,5 +516,20 @@ Licensed under the MIT License. See LICENSE file for details.
     </data>
     <data name="SCRAPE_ASK_DIALOG_INFO" xml:space="preserve">
         <value>You can update the model library at any time in the Settings.</value>
+    </data>
+    <data name="UPDATE_CHECK_SETTING" xml:space="preserve">
+        <value>Update checking</value>
+    </data>
+    <data name="UPDATE_CHECK_SETTING_DESC" xml:space="preserve">
+        <value>When enabled, the application will automatically check if a newer version is available during startup.</value>
+    </data>
+    <data name="UPDATE_AVAILABLE" xml:space="preserve">
+        <value>An update is available</value>
+    </data>
+    <data name="OPEN_GITHUB" xml:space="preserve">
+        <value>Open GitHub</value>
+    </data>
+    <data name="UPDATE_AVAILABLE_DESC" xml:space="preserve">
+        <value>To update, download the latest release from our GitHub page.</value>
     </data>
 </root>

--- a/avallama/Constants/ConfigurationKey.cs
+++ b/avallama/Constants/ConfigurationKey.cs
@@ -15,4 +15,5 @@ public static class ConfigurationKey
     public const string IsParallelDownloadEnabled = "is-parallel-download-enabled";
     public const string LastUpdatedCache = "last-updated-cache";
     public const string InitialScrapeAskDialogHandled = "initial-scrape-ask-dialog-handled";
+    public const string IsUpdateCheckEnabled = "is-update-checking-enabled";
 }

--- a/avallama/Extensions/ServiceCollectionExtensions.cs
+++ b/avallama/Extensions/ServiceCollectionExtensions.cs
@@ -82,6 +82,9 @@ public static class ServiceCollectionExtensions
             collection.AddSingleton<ModelCacheService>();
             collection.AddSingleton<IModelCacheService>(sp => sp.GetRequiredService<ModelCacheService>());
 
+            collection.AddTransient<UpdateService>();
+            collection.AddTransient<IUpdateService>(sp => sp.GetRequiredService<UpdateService>());
+
             collection.AddSingleton<DialogService>();
             collection.AddSingleton<IDialogService>(sp => sp.GetRequiredService<DialogService>());
 

--- a/avallama/Services/Ollama/OllamaScraperService.cs
+++ b/avallama/Services/Ollama/OllamaScraperService.cs
@@ -26,15 +26,8 @@ public interface IOllamaScraperService
     Task<OllamaScraperResult> GetAllOllamaModelsAsync(CancellationToken cancellationToken);
 }
 
-public class OllamaScraperService : IOllamaScraperService
+public class OllamaScraperService(HttpClient httpClient) : IOllamaScraperService
 {
-    private readonly HttpClient _httpClient;
-
-    public OllamaScraperService(HttpClient httpClient)
-    {
-        _httpClient = httpClient;
-    }
-
     public async Task<OllamaScraperResult> GetAllOllamaModelsAsync(
         CancellationToken cancellationToken)
     {
@@ -99,7 +92,7 @@ public class OllamaScraperService : IOllamaScraperService
     {
         try
         {
-            using var response = await _httpClient.GetAsync("/library", ct);
+            using var response = await httpClient.GetAsync("/library", ct);
 
             if (!response.IsSuccessStatusCode) return [];
 
@@ -159,6 +152,9 @@ public class OllamaScraperService : IOllamaScraperService
                 }
             }
 
+            // TODO: remove this once image models are supported
+            result = result.Where(f => !f.Labels.Contains("image")).ToList();
+
             return result;
         }
         catch (Exception)
@@ -178,7 +174,7 @@ public class OllamaScraperService : IOllamaScraperService
 
         try
         {
-            using var tagsResponse = await _httpClient.GetAsync(familyUrl, ct);
+            using var tagsResponse = await httpClient.GetAsync(familyUrl, ct);
 
             if (tagsResponse.IsSuccessStatusCode)
             {
@@ -222,7 +218,17 @@ public class OllamaScraperService : IOllamaScraperService
                 Family = family
             };
 
+            if (!IsValidModel(model)) continue;
+
+            // TODO: Remove this once image models are supported
+            if (model.Name.Contains("image")) continue;
+
             yield return model;
         }
+    }
+
+    private static bool IsValidModel(OllamaModel model)
+    {
+        return !model.Name.Contains("cloud") && !model.Name.Contains("latest") && model.Size > 0;
     }
 }

--- a/avallama/Services/UpdateService.cs
+++ b/avallama/Services/UpdateService.cs
@@ -1,0 +1,57 @@
+﻿using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+using avallama.Utilities.Network;
+
+namespace avallama.Services;
+
+/// <summary>
+/// Service responsible for checking if a new version of the application is available
+/// </summary>
+public interface IUpdateService
+{
+    /// <summary>
+    /// Checks if a new version of the application is available by querying the GitHub API for the latest release
+    /// and comparing it to the current version, which is stored in the "VERSION" localization string.
+    /// </summary>
+    /// <returns> True if an update is available, false otherwise </returns>
+    Task<bool> IsUpdateAvailableAsync();
+}
+
+public class UpdateService : IUpdateService
+{
+    private readonly string _version;
+    private readonly HttpClient _httpClient;
+    private readonly INetworkManager _networkManager;
+
+    public UpdateService(HttpClient httpClient, INetworkManager networkManager)
+    {
+        _version = App.Version;
+        _httpClient = httpClient;
+        _httpClient.DefaultRequestHeaders.UserAgent.Add(
+            new ProductInfoHeaderValue("avallama", _version));
+        _httpClient.DefaultRequestHeaders.Accept.Add(
+            new MediaTypeWithQualityHeaderValue("application/vnd.github+json"));
+        _networkManager = networkManager;
+    }
+
+    /// <inheritdoc/>
+    public async Task<bool> IsUpdateAvailableAsync()
+    {
+        // If no internet is available, assume no update is available
+        if (!await _networkManager.IsInternetAvailableAsync()) return false;
+
+        var response = await _httpClient.GetAsync(
+            "https://api.github.com/repos/4foureyes/avallama/releases/latest");
+
+        // If request fails, assume no update is available
+        if (!response.IsSuccessStatusCode) return false;
+
+        var json = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(json);
+        var latestVersion = doc.RootElement.GetProperty("tag_name").GetString();
+        return latestVersion != _version;
+    }
+}

--- a/avallama/ViewModels/HomeViewModel.cs
+++ b/avallama/ViewModels/HomeViewModel.cs
@@ -36,6 +36,7 @@ public partial class HomeViewModel : PageViewModel
     private readonly IDialogService _dialogService;
     private readonly IConfigurationService _configurationService;
     private readonly IConversationService _conversationService;
+    private readonly IUpdateService _updateService;
     private readonly IMessenger _messenger;
 
     // Internal State
@@ -141,12 +142,14 @@ public partial class HomeViewModel : PageViewModel
     /// <param name="dialogService">Service for displaying dialogs.</param>
     /// <param name="configurationService">Service for application settings.</param>
     /// <param name="conversationService">Service for conversation interactions.</param>
+    /// <param name="updateService">Service for checking application updates.</param>
     /// <param name="messenger">Messenger for cross-component communication.</param>
     public HomeViewModel(
         IOllamaService ollamaService,
         IDialogService dialogService,
         IConfigurationService configurationService,
         IConversationService conversationService,
+        IUpdateService updateService,
         IMessenger messenger
     )
     {
@@ -156,6 +159,7 @@ public partial class HomeViewModel : PageViewModel
         _dialogService = dialogService;
         _configurationService = configurationService;
         _conversationService = conversationService;
+        _updateService = updateService;
         _messenger = messenger;
         _availableModels = [];
 
@@ -182,6 +186,8 @@ public partial class HomeViewModel : PageViewModel
             if (!_isInitializedAsync)
             {
                 await InitializeConversations();
+                if (_configurationService.ReadSetting(ConfigurationKey.IsUpdateCheckEnabled) == "True")
+                    await CheckForUpdatesAsync();
             }
 
             await InitializeModels();
@@ -467,6 +473,34 @@ public partial class HomeViewModel : PageViewModel
         {
             // sets the previously selected model
             SelectedModelName = tmpName;
+        }
+    }
+
+    /// <summary>
+    /// Calls <see cref="UpdateService"/> to check if a new version of the application is available.
+    /// If an update is available, shows a dialog prompting the user to visit the GitHub releases page.
+    /// If the <see cref="ConfigurationKey"/> IsUpdateCheckEnabled is false, this method is not called.
+    /// </summary>
+    private async Task CheckForUpdatesAsync()
+    {
+        if (await _updateService.IsUpdateAvailableAsync())
+        {
+            _dialogService.ShowActionDialog(
+                LocalizationService.GetString("UPDATE_AVAILABLE"),
+                LocalizationService.GetString("OPEN_GITHUB"),
+                () =>
+                {
+                    Process.Start(new ProcessStartInfo
+                        {
+                            FileName = "https://github.com/4foureyes/avallama/releases/latest",
+                            UseShellExecute = true
+                        }
+                    );
+                },
+                null,
+                LocalizationService.GetString("UPDATE_AVAILABLE_DESC"),
+                false
+            );
         }
     }
 

--- a/avallama/ViewModels/SettingsViewModel.cs
+++ b/avallama/ViewModels/SettingsViewModel.cs
@@ -141,6 +141,16 @@ public partial class SettingsViewModel : PageViewModel
         }
     }
 
+    public bool IsUpdateCheckEnabled
+    {
+        get;
+        set
+        {
+            field = value;
+            OnPropertyChanged();
+        }
+    }
+
     public SettingsViewModel(DialogService dialogService, ConfigurationService configurationService,
         IMessenger messenger, INetworkManager networkManager)
     {
@@ -192,6 +202,9 @@ public partial class SettingsViewModel : PageViewModel
 
         var isParallelDownloadEnabled = _configurationService.ReadSetting(ConfigurationKey.IsParallelDownloadEnabled);
         IsParallelDownloadEnabled = isParallelDownloadEnabled == "True";
+
+        var isUpdateCheckEnabled = _configurationService.ReadSetting(ConfigurationKey.IsUpdateCheckEnabled);
+        IsUpdateCheckEnabled = isUpdateCheckEnabled == "True";
 
         var lastModelUpdate = _configurationService.ReadSetting(ConfigurationKey.LastUpdatedCache);
         LastModelUpdate = LocalizationService.GetString("LAST_UPDATED") + ": " + (!lastModelUpdate.Equals(string.Empty) ? lastModelUpdate : LocalizationService.GetString("NEVER"));
@@ -245,6 +258,8 @@ public partial class SettingsViewModel : PageViewModel
             IsInformationalMessagesVisible.ToString());
         _configurationService.SaveSetting(ConfigurationKey.IsParallelDownloadEnabled,
             IsParallelDownloadEnabled.ToString());
+        _configurationService.SaveSetting(ConfigurationKey.IsUpdateCheckEnabled,
+            IsUpdateCheckEnabled.ToString());
 
         _messenger.Send(new ApplicationMessage.ReloadSettings());
 

--- a/avallama/Views/SettingsView.axaml
+++ b/avallama/Views/SettingsView.axaml
@@ -21,7 +21,7 @@ Licensed under the MIT License. See LICENSE file for details.
                            Classes="H1" Margin="0,0,0,20" />
 
                 <!-- Setting items -->
-                <Grid Grid.Row="1" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto" RowSpacing="24"
+                <Grid Grid.Row="1" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto" RowSpacing="24"
                       ColumnDefinitions="500, *"
                       Margin="0,0,26,0">
                     <!-- Language -->
@@ -123,13 +123,26 @@ Licensed under the MIT License. See LICENSE file for details.
                                   OffContent="{services:LocalizationService Key='OFF'}"
                                   OnContent="{services:LocalizationService Key='ON'}" />
 
+                    <!-- Update checking setting -->
+                    <StackPanel Grid.Row="7" Grid.Column="0" VerticalAlignment="Center">
+                        <TextBlock Text="{services:LocalizationService Key='UPDATE_CHECK_SETTING'}"
+                                   FontSize="18" Foreground="{DynamicResource OnSurface}" />
+                        <TextBlock Text="{services:LocalizationService Key='UPDATE_CHECK_SETTING_DESC'}"
+                                   Margin="0,2,0,0" Foreground="{DynamicResource Outline}"
+                                   TextWrapping="Wrap" />
+                    </StackPanel>
+                    <ToggleSwitch Grid.Row="7" Grid.Column="1" IsChecked="{Binding IsUpdateCheckEnabled}"
+                                  VerticalAlignment="Center" HorizontalAlignment="Right" Cursor="Hand"
+                                  OffContent="{services:LocalizationService Key='OFF'}"
+                                  OnContent="{services:LocalizationService Key='ON'}" />
+
                     <!-- Reset settings to default -->
-                    <Button Grid.Row="7" Grid.Column="1" Margin="0,20,0,0"
+                    <Button Grid.Row="8" Grid.Column="1" Margin="0,20,0,0"
                             Content="{services:LocalizationService Key='RESET_TO_DEFAULT'}"
                             HorizontalAlignment="Right" Cursor="Hand" Classes="secondaryButton"
                             Command="{Binding ResetSettingsToDefault}" />
 
-                    <StackPanel Grid.Row="7" Grid.Column="0" HorizontalAlignment="Left" Orientation="Horizontal"
+                    <StackPanel Grid.Row="8" Grid.Column="0" HorizontalAlignment="Left" Orientation="Horizontal"
                                 Spacing="14" Margin="0,20,0,0">
                         <!-- Update model library -->
                         <Button Content="{services:LocalizationService Key='UPDATE_MODEL_LIBRARY'}"


### PR DESCRIPTION
Fixes https://github.com/4foureyes/avallamaplanning/issues/120
Closes https://github.com/4foureyes/avallamaplanning/issues/112

Changes:
Update checking
- Created `UpdateService` which checks for an update by calling the https://api.github.com/repos/4foureyes/avallama/releases/latest endpoint and comparing it against the current version stored in the `VERSION` localization string.
- Added tests for this service
- Implemented the service in HomeViewModel initialization, here if the "Update checking" setting is set to `False` then the check does not run.
- Refactored `HomeViewModelTests` a little to avoid future pain
- Created the "Update checking" setting which disables the update checking if turned off

Removing invalid models from scraping
- Added logic exclude models from being saved to the model manager that contain `cloud` or `latest` in their name
- Also added temporary logic to exclude `image` models from scraping which can be removed once image models are supported.