### PR TITLE
Fix deb package for Ubuntu, add logs to build scripts

### DIFF
--- a/avallama/Views/GreetingView.axaml
+++ b/avallama/Views/GreetingView.axaml
@@ -1,4 +1,4 @@
-<!-- 
+<!--
 Copyright (c) Márk Csörgő and Martin Bartos
 Licensed under the MIT License. See LICENSE file for details.
 -->
@@ -9,6 +9,7 @@ Licensed under the MIT License. See LICENSE file for details.
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:localization="clr-namespace:avallama.Services"
+             xmlns:avallama="clr-namespace:avallama"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              Background="{DynamicResource Surface}"
              x:Class="avallama.Views.GreetingView"
@@ -34,7 +35,7 @@ Licensed under the MIT License. See LICENSE file for details.
             </StackPanel>
         </StackPanel>
 
-        <TextBlock Text="{localization:LocalizationService Key='VERSION'}"
+        <TextBlock Text="{x:Static avallama:App.Version}"
                    HorizontalAlignment="Right"
                    VerticalAlignment="Bottom"
                    Margin="10"


### PR DESCRIPTION
Fixes https://github.com/4foureyes/avallamaplanning/issues/122
Closes https://github.com/4foureyes/avallamaplanning/issues/128

Changes:
- Fixed Debian package by allowing multiple versions of libicu, so older versions of Ubuntu can select and older version. I tested the installation on Ubuntu and it worked as expected
- Added basic logging to the packaging scripts, except the Windows once since that already logs most info on its own. An example of the logs can be found below.
- Removed the `!strip` option in the Arch build script so it produces stripped binaries
- Fixed the version tag in `GreetingView` since it still used the localization key which was removed in a previous commit.

Example output of macOS build script now:
```
Run chmod +x scripts/package-macos.sh
2026-02-12T19:56:03Z [INFO] Starting macOS package script
2026-02-12T19:56:03Z [INFO] Checking for native source code
2026-02-12T19:56:03Z [INFO] Compiling native macOS source code
2026-02-12T19:56:04Z [INFO] Running dotnet publish for osx-x64
  Determining projects to restore...
  Restored /Users/runner/work/avallama/avallama/avallama/avallama.csproj (in 3.44 sec).
Warning: /Users/runner/work/avallama/avallama/avallama/Utilities/DiskManager.cs(37,28): warning CS0168: The variable 'ex' is declared but never used [/Users/runner/work/avallama/avallama/avallama/avallama.csproj]
Warning: /Users/runner/work/avallama/avallama/avallama/Utilities/DiskManager.cs(57,28): warning CS0168: The variable 'ex' is declared but never used [/Users/runner/work/avallama/avallama/avallama/avallama.csproj]
  avallama -> /Users/runner/work/avallama/avallama/avallama/bin/Release/net10.0/osx-x64/avallama.dll
  avallama -> /Users/runner/work/avallama/avallama/mac-dist-x64/
2026-02-12T19:56:19Z [INFO] Running dotnet publish for osx-arm64
  Determining projects to restore...
  Restored /Users/runner/work/avallama/avallama/avallama/avallama.csproj (in 1.04 sec).
Warning: /Users/runner/work/avallama/avallama/avallama/Utilities/DiskManager.cs(37,28): warning CS0168: The variable 'ex' is declared but never used [/Users/runner/work/avallama/avallama/avallama/avallama.csproj]
Warning: /Users/runner/work/avallama/avallama/avallama/Utilities/DiskManager.cs(57,28): warning CS0168: The variable 'ex' is declared but never used [/Users/runner/work/avallama/avallama/avallama/avallama.csproj]
  avallama -> /Users/runner/work/avallama/avallama/avallama/bin/Release/net10.0/osx-arm64/avallama.dll
  avallama -> /Users/runner/work/avallama/avallama/mac-dist-arm64/
2026-02-12T19:56:25Z [INFO] Creating .app structure for x64
2026-02-12T19:56:26Z [INFO] [create_app_structure()] Adding universal dylib to .app for mac-dist-x64
2026-02-12T19:56:26Z [INFO] [create_app_structure()] Creating Info.plist for mac-dist-x64
2026-02-12T19:56:26Z [INFO] Creating DMG installer for x64
Creating disk image...
created: /Users/runner/work/avallama/avallama/rw.2135.avallama_0.0.1_osx_x64.dmg
Mounting disk image...
Device name:     /dev/disk6
Searching for mounted interstitial disk image using /dev/disk6s... 
Mount dir:       /Volumes/dmg.yY6Rjq
Making link to Applications dir...
/Volumes/dmg.yY6Rjq
Will sleep for 2 seconds to workaround occasions "Can't get disk (-1728)" issues...
Running AppleScript to make Finder stuff pretty: /usr/bin/osascript "/var/folders/yz/zr09txvs5dn18vt4cn21kzl40000gn/T/createdmg.tmp.XXXXXXXXXX.x2pHsXb7SW" "dmg.yY6Rjq"
waited 1 seconds for .DS_STORE to be created.
Done running the AppleScript...
Fixing permissions...
Done fixing permissions
Skipping blessing on sandbox
Deleting .fseventsd
Unmounting disk image...
"disk6" ejected.
Compressing disk image...
Preparing imaging engine…
Reading Protective Master Boot Record (MBR : 0)…
   (CRC32 $8CFFF43D: Protective Master Boot Record (MBR : 0))
Reading GPT Header (Primary GPT Header : 1)…
   (CRC32 $AB549A89: GPT Header (Primary GPT Header : 1))
Reading GPT Partition Data (Primary GPT Table : 2)…
   (CRC32 $A34A9FCA: GPT Partition Data (Primary GPT Table : 2))
Reading  (Apple_Free : 3)…
   (CRC32 $00000000:  (Apple_Free : 3))
Reading disk image (Apple_HFS : 4)…
   (CRC32 $476D1BAA: disk image (Apple_HFS : 4))
Reading  (Apple_Free : 5)…
   (CRC32 $00000000:  (Apple_Free : 5))
Reading GPT Partition Data (Backup GPT Table : 6)…
   (CRC32 $A34A9FCA: GPT Partition Data (Backup GPT Table : 6))
Reading GPT Header (Backup GPT Header : 7)…
   (CRC32 $E0737D9B: GPT Header (Backup GPT Header : 7))
Adding resources…
Elapsed Time:  4.602s
File size: 50730712 bytes, Checksum: CRC32 $0233C93C
Sectors processed: 280653, 222252 compressed
Speed: 23.6MB/s
Savings: 64.7%
created: /Users/runner/work/avallama/avallama/avallama_0.0.1_osx_x64.dmg
Not setting 'internet-enable' on the dmg, per caller request
Disk image done
2026-02-12T19:56:50Z [INFO] Creating .app structure for arm64
2026-02-12T19:56:50Z [INFO] [create_app_structure()] Adding universal dylib to .app for mac-dist-arm64
2026-02-12T19:56:50Z [INFO] [create_app_structure()] Creating Info.plist for mac-dist-arm64
2026-02-12T19:56:50Z [INFO] Creating DMG installer for arm64
Creating disk image...
created: /Users/runner/work/avallama/avallama/rw.2436.avallama_0.0.1_osx_arm64.dmg
Mounting disk image...
Device name:     /dev/disk6
Searching for mounted interstitial disk image using /dev/disk6s... 
Mount dir:       /Volumes/dmg.mIpGby
Making link to Applications dir...
/Volumes/dmg.mIpGby
Will sleep for 2 seconds to workaround occasions "Can't get disk (-1728)" issues...
Running AppleScript to make Finder stuff pretty: /usr/bin/osascript "/var/folders/yz/zr09txvs5dn18vt4cn21kzl40000gn/T/createdmg.tmp.XXXXXXXXXX.nWE7wWNsL6" "dmg.mIpGby"
waited 1 seconds for .DS_STORE to be created.
Done running the AppleScript...
Fixing permissions...
Done fixing permissions
Skipping blessing on sandbox
Deleting .fseventsd
Unmounting disk image...
"disk6" ejected.
Compressing disk image...
Preparing imaging engine…
Reading Protective Master Boot Record (MBR : 0)…
   (CRC32 $7FBF5FDA: Protective Master Boot Record (MBR : 0))
Reading GPT Header (Primary GPT Header : 1)…
   (CRC32 $319459E4: GPT Header (Primary GPT Header : 1))
Reading GPT Partition Data (Primary GPT Table : 2)…
   (CRC32 $E6F2D998: GPT Partition Data (Primary GPT Table : 2))
Reading  (Apple_Free : 3)…
   (CRC32 $00000000:  (Apple_Free : 3))
Reading disk image (Apple_HFS : 4)…
   (CRC32 $96F74514: disk image (Apple_HFS : 4))
Reading GPT Partition Data (Backup GPT Table : 5)…
   (CRC32 $E6F2D998: GPT Partition Data (Backup GPT Table : 5))
Reading GPT Header (Backup GPT Header : 6)…
   (CRC32 $B0008315: GPT Header (Backup GPT Header : 6))
Adding resources…
Elapsed Time:  6.196s
File size: 48808832 bytes, Checksum: CRC32 $47B24D62
Sectors processed: 294985, 236452 compressed
Speed: 18.6MB/s
Savings: 67.7%
created: /Users/runner/work/avallama/avallama/avallama_0.0.1_osx_arm64.dmg
Not setting 'internet-enable' on the dmg, per caller request
Disk image done
2026-02-12T19:57:13Z [INFO] Cleaning up temporary files
2026-02-12T19:57:13Z [INFO] Done: Created avallama_0.0.1_osx_x64.dmg and avallama_0.0.1_osx_arm64.dmg
```