### PR TITLE
Add Ollama process manager to handle all OS-level process operations for Ollama separately

### DIFF
--- a/avallama.Tests/Services/OllamaProcessManagerTests.cs
+++ b/avallama.Tests/Services/OllamaProcessManagerTests.cs
@@ -1,0 +1,70 @@
+// Copyright (c) Márk Csörgő and Martin Bartos
+// Licensed under the MIT License. See LICENSE file for details.
+
+using System.Threading.Tasks;
+using avallama.Constants.States;
+using avallama.Services.Ollama;
+using avallama.Tests.Fixtures;
+using avallama.Tests.Mocks;
+using Xunit;
+
+namespace avallama.Tests.Services;
+
+public class OllamaProcessManagerTests(TestServicesFixture fixture) : IClassFixture<TestServicesFixture>
+{
+    [Fact]
+    public async Task StartAsync_SetsStartingState()
+    {
+        var opm = new OllamaProcessManager
+        {
+            StartProcessFunc = _ => new OllamaProcessMock(),
+            GetProcessesFunc = () => []
+        };
+
+        var stateChanged = false;
+        var processState = OllamaProcessState.Stopped;
+
+        opm.StatusChanged += status =>
+        {
+            if (stateChanged) return;
+            processState = status.ProcessState;
+            stateChanged = true;
+        };
+
+        await opm.StartAsync();
+
+        Assert.Equal(OllamaProcessState.Starting, processState);
+    }
+
+    [Fact]
+    public async Task StartAsync_WhenProcessIsNull_SetsNotInstalledState()
+    {
+        var opm = new OllamaProcessManager
+        {
+            StartProcessFunc = _ => null,
+            GetProcessesFunc = () => []
+        };
+
+        var processState = OllamaProcessState.Stopped;
+        opm.StatusChanged += status => processState = status.ProcessState;
+        await opm.StartAsync();
+
+        Assert.Equal(OllamaProcessState.NotInstalled, processState);
+    }
+
+    [Fact]
+    public async Task StartAsync_WithProcessRunning_SetsRunningState()
+    {
+        var opm = new OllamaProcessManager
+        {
+            StartProcessFunc = _ => new OllamaProcessMock(),
+            GetProcessesFunc = () => [ new OllamaProcessMock() ]
+        };
+
+        var processState = OllamaProcessState.Stopped;
+        opm.StatusChanged += status => processState = status.ProcessState;
+        await opm.StartAsync();
+
+        Assert.Equal(OllamaProcessState.Running, processState);
+    }
+}

--- a/avallama.Tests/Services/OllamaProcessManagerTests.cs
+++ b/avallama.Tests/Services/OllamaProcessManagerTests.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace avallama.Tests.Services;
 
-public class OllamaProcessManagerTests(TestServicesFixture fixture) : IClassFixture<TestServicesFixture>
+public class OllamaProcessManagerTests : IClassFixture<TestServicesFixture>
 {
     [Fact]
     public async Task StartAsync_SetsStartingState()

--- a/avallama/Constants/States/OllamaProcessState.cs
+++ b/avallama/Constants/States/OllamaProcessState.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Márk Csörgő and Martin Bartos
+// Licensed under the MIT License. See LICENSE file for details.
+
+namespace avallama.Constants.States;
+
+/// <summary>
+/// Defines the lifecycle states of the local Ollama executable process.
+/// </summary>
+public enum OllamaProcessState
+{
+    /// <summary>
+    /// The process is currently starting up.
+    /// </summary>
+    Starting,
+
+    /// <summary>
+    /// The process is actively running.
+    /// </summary>
+    Running,
+
+    /// <summary>
+    /// The process has been stopped or has not been started yet.
+    /// </summary>
+    Stopped,
+
+    /// <summary>
+    /// The process failed to start or exited unexpectedly.
+    /// </summary>
+    Failed,
+
+    /// <summary>
+    /// The Ollama executable was not found on the system.
+    /// </summary>
+    NotInstalled
+}

--- a/avallama/Extensions/ServiceCollectionExtensions.cs
+++ b/avallama/Extensions/ServiceCollectionExtensions.cs
@@ -48,6 +48,9 @@ public static class ServiceCollectionExtensions
             collection.AddSingleton<ConversationService>();
             collection.AddSingleton<IConversationService>(sp => sp.GetRequiredService<ConversationService>());
 
+            collection.AddSingleton<OllamaProcessManager>();
+            collection.AddSingleton<IOllamaProcessManager>(sp => sp.GetRequiredService<OllamaProcessManager>());
+
             collection.AddSingleton<OllamaService>();
             collection.AddSingleton<IOllamaService>(sp => sp.GetRequiredService<OllamaService>());
 

--- a/avallama/Models/Ollama/OllamaProcessStatus.cs
+++ b/avallama/Models/Ollama/OllamaProcessStatus.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Márk Csörgő and Martin Bartos
+// Licensed under the MIT License. See LICENSE file for details.
+
+using avallama.Constants.States;
+
+namespace avallama.Models.Ollama;
+
+/// <summary>
+/// Represents the current status of the local Ollama process.
+/// </summary>
+/// <param name="processState">The current state of the process.</param>
+/// <param name="message">An optional message providing details about the state (e.g. error messages).</param>
+public class OllamaProcessStatus(OllamaProcessState processState, string? message = null)
+{
+    /// <summary>
+    /// Gets or sets the current state of the local Ollama process.
+    /// </summary>
+    public OllamaProcessState ProcessState { get; set; } = processState;
+
+    /// <summary>
+    /// Gets or sets an optional message regarding the process status.
+    /// </summary>
+    public string? Message { get; set; } = message;
+}

--- a/avallama/Services/Ollama/OllamaProcessManager.cs
+++ b/avallama/Services/Ollama/OllamaProcessManager.cs
@@ -1,0 +1,370 @@
+// Copyright (c) Márk Csörgő and Martin Bartos
+// Licensed under the MIT License. See LICENSE file for details.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using avallama.Constants.States;
+using avallama.Models.Ollama;
+
+namespace avallama.Services.Ollama;
+
+// TODO:
+// stop process when user changes to a remote connection and restart if its changed to local
+// (only if the user started the process from Avallama, otherwise ignore it)
+
+/// <summary>
+/// Delegate for handling changes in the Ollama process status.
+/// </summary>
+public delegate void OllamaProcessStatusChangedHandler(OllamaProcessStatus status);
+
+/// <summary>
+/// Defines a contract for managing the lifecycle of the local Ollama process.
+/// </summary>
+public interface IOllamaProcessManager
+{
+    #region Interface
+
+    /// <summary>
+    /// Gets the current status of the Ollama process.
+    /// </summary>
+    OllamaProcessStatus Status { get; }
+
+    /// <summary>
+    /// Event raised when the process status changes.
+    /// </summary>
+    event OllamaProcessStatusChangedHandler? StatusChanged;
+
+    /// <summary>
+    /// Starts the Ollama process asynchronously.
+    /// </summary>
+    Task StartAsync();
+
+    /// <summary>
+    /// Stops the Ollama process asynchronously.
+    /// </summary>
+    Task StopAsync();
+
+    #endregion
+}
+
+/// <summary>
+/// Manages the lifecycle of the local Ollama server process, including starting, stopping, and monitoring its status.
+/// Handles both processes started by the application and existing instances.
+/// </summary>
+public class OllamaProcessManager : IOllamaProcessManager, IDisposable
+{
+    #region Dependencies & Fields
+
+    /// <summary>
+    /// Function to create and start a new process. Can be replaced for testing purposes.
+    /// </summary>
+    public Func<ProcessStartInfo, IOllamaProcess?> StartProcessFunc { get; init; } = psi =>
+    {
+        var process = Process.Start(psi);
+        return process != null ? new OllamaProcess(process) : null;
+    };
+
+    /// <summary>
+    /// Function to retrieve running processes. Can be replaced for testing purposes.
+    /// </summary>
+    public Func<IEnumerable<IOllamaProcess>> GetProcessesFunc { get; init; }
+
+    /// <summary>
+    /// Function to check if Ollama is running as a systemd service (Linux only). Can be replaced for testing purposes.
+    /// </summary>
+    public Func<bool> CheckSystemdStatusFunc { get; init; }
+
+    private readonly SemaphoreSlim _startSemaphore = new(1, 1);
+    private string OllamaPath { get; set; } = "";
+    private IOllamaProcess? _ollamaProcess;
+    private bool _isProcessStartedByAvallama;
+
+    #endregion
+
+    #region Constructor
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OllamaProcessManager"/> class.
+    /// </summary>
+    public OllamaProcessManager()
+    {
+        // Initialize default implementations if not provided (e.g., by tests)
+        GetProcessesFunc ??= () => Process.GetProcessesByName("ollama").Select(p => new OllamaProcess(p));
+        CheckSystemdStatusFunc ??= IsOllamaRunningAsSystemdService;
+    }
+
+    #endregion
+
+    #region Event & Status
+
+    public event OllamaProcessStatusChangedHandler? StatusChanged;
+
+    public OllamaProcessStatus Status
+    {
+        get;
+        private set
+        {
+            if (field == value) return;
+            field = value;
+            StatusChanged?.Invoke(value);
+        }
+    } = new(OllamaProcessState.Stopped);
+
+    #endregion
+
+    #region Public Methods
+
+    public async Task StartAsync()
+    {
+        await _startSemaphore.WaitAsync();
+
+        try
+        {
+            Status = new OllamaProcessStatus(OllamaProcessState.Starting);
+
+            ConfigureOllamaPath();
+
+            // check for existing instances (real server processes).
+            // we get all processes named "ollama" and ensure they don't have a window handle
+            // (to distinguish from GUI wrappers).
+            var ollamaServerProcesses = GetProcessesFunc()
+                .Where(p => p.MainWindowHandle == IntPtr.Zero)
+                .Where(p => !p.ProcessName.Equals("Ollama", StringComparison.Ordinal))
+                .ToArray();
+
+            if (ollamaServerProcesses.Length == 1)
+            {
+                // attach to the existing process
+                _isProcessStartedByAvallama = false;
+                _ollamaProcess = ollamaServerProcesses.FirstOrDefault();
+                if (_ollamaProcess != null)
+                {
+                    _ollamaProcess.EnableRaisingEvents = true;
+                    _ollamaProcess.Exited += OnOllamaProcessExited;
+                }
+
+                Status = new OllamaProcessStatus(OllamaProcessState.Running,
+                    LocalizationService.GetString("OLLAMA_ALREADY_RUNNING"));
+                return;
+            }
+            else if (ollamaServerProcesses.Length > 1)
+            {
+                _isProcessStartedByAvallama = false;
+                // multiple instances found, report failure rather than attempting to kill them
+                Status = new OllamaProcessStatus(OllamaProcessState.Failed,
+                    LocalizationService.GetString("MULTIPLE_INSTANCES_ERROR"));
+                return;
+            }
+
+            // TODO: Add custom env variables (e.g. OLLAMA_MODELS for saving local models at a custom path)
+            // attempt to start a new process
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = OllamaPath,
+                Arguments = "serve",
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+
+            IOllamaProcess? tempProcess = null;
+            try
+            {
+                tempProcess = StartProcessFunc(startInfo);
+                if (tempProcess != null)
+                {
+                    tempProcess.EnableRaisingEvents = true;
+                    tempProcess.Exited += OnOllamaProcessExited;
+
+                    // Only set newly started process if everything ran correctly without exceptions
+                    _ollamaProcess = tempProcess;
+                    _isProcessStartedByAvallama = true;
+                    Status = new OllamaProcessStatus(OllamaProcessState.Running);
+                    return;
+                }
+
+                Status = new OllamaProcessStatus(OllamaProcessState.NotInstalled);
+            }
+            catch (Win32Exception)
+            {
+                Status = new OllamaProcessStatus(OllamaProcessState.NotInstalled);
+                try { tempProcess?.Kill(); } catch { /* ignore */ }
+                tempProcess?.Dispose();
+            }
+            catch (Exception ex)
+            {
+                Status = new OllamaProcessStatus(OllamaProcessState.Failed,
+                    string.Format(LocalizationService.GetString("OLLAMA_FAILED"), ex.Message));
+                try { tempProcess?.Kill(); } catch { /* ignore */ }
+                tempProcess?.Dispose();
+            }
+        }
+        finally
+        {
+            _startSemaphore.Release();
+        }
+    }
+
+    public async Task StopAsync()
+    {
+        await _startSemaphore.WaitAsync();
+
+        // do not stop if the user started the process outside the app
+        if (!_isProcessStartedByAvallama)
+        {
+            _startSemaphore.Release();
+            return;
+        }
+
+        try
+        {
+            // on Linux, check if running as a systemd service before attempting to kill
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && CheckSystemdStatusFunc())
+            {
+                return;
+            }
+
+            // kills the Ollama process
+            if (_ollamaProcess != null)
+            {
+                _ollamaProcess.EnableRaisingEvents = false;
+                _ollamaProcess.Exited -= OnOllamaProcessExited;
+                _ollamaProcess.Kill();
+                await _ollamaProcess.WaitForExitAsync();
+                _ollamaProcess.Dispose();
+                _isProcessStartedByAvallama = false;
+            }
+        }
+        finally
+        {
+            _startSemaphore.Release();
+        }
+
+        _ollamaProcess = null;
+        Status = new OllamaProcessStatus(OllamaProcessState.Stopped);
+    }
+
+    #endregion
+
+    #region Private Methods
+
+    private void OnOllamaProcessExited(object? sender, EventArgs e)
+    {
+        // ignore process exit if the user stopped the process intentionally via the app
+        if (Status.ProcessState == OllamaProcessState.Stopped) return;
+
+        string? message = null;
+        var newState = OllamaProcessState.Stopped;
+
+        if (sender is IOllamaProcess process)
+        {
+            try
+            {
+                if (process.ExitCode != 0)
+                {
+                    newState = OllamaProcessState.Failed;
+                    message = LocalizationService.GetString("OLLAMA_STOPPED_UNEXPECTEDLY")
+                              + $" ({LocalizationService.GetString("EXIT_CODE")}: {process.ExitCode})";
+                }
+            }
+            catch (Exception)
+            {
+                newState = OllamaProcessState.Failed;
+                message = LocalizationService.GetString("OLLAMA_STOPPED_UNEXPECTEDLY");
+            }
+        }
+
+        Status = new OllamaProcessStatus(newState, message);
+
+        _ollamaProcess?.Dispose();
+        _ollamaProcess = null;
+    }
+
+    private void ConfigureOllamaPath()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            OllamaPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                @"Programs\Ollama\ollama");
+        }
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ||
+                 RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            OllamaPath = @"/usr/local/bin/ollama";
+        }
+    }
+
+    private static bool IsOllamaRunningAsSystemdService()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            throw new InvalidOperationException("Systemd check should only be called on Linux");
+        }
+
+        var psiRoot = new ProcessStartInfo
+        {
+            FileName = "systemctl",
+            Arguments = "is-active ollama",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        var psiUser = new ProcessStartInfo
+        {
+            FileName = "systemctl",
+            Arguments = "--user is-active ollama",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        try
+        {
+            // Check system-level service
+            using var processRoot = Process.Start(psiRoot);
+            if (processRoot == null) return false;
+
+            processRoot.WaitForExit();
+            if (processRoot.StandardOutput.ReadToEnd().Trim() == "active") return true;
+
+            // Retry with user-level service
+            using var processUser = Process.Start(psiUser);
+            if (processUser == null) return false;
+
+            processUser.WaitForExit();
+            return processUser.StandardOutput.ReadToEnd().Trim() == "active";
+        }
+        catch (Win32Exception ex) when (ex.NativeErrorCode == 2)
+        {
+            // 'systemctl' command not found
+            return false;
+        }
+        catch (Win32Exception)
+        {
+            // Permission denied or other errors
+            return false;
+        }
+    }
+
+    #endregion
+
+    #region Dispose
+
+    public void Dispose()
+    {
+        _startSemaphore.Dispose();
+        StopAsync().GetAwaiter().GetResult();
+        GC.SuppressFinalize(this);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Changes
- Introduced a new `OllamaProcessManager class dedicated to handling all OS-level process operations for Ollama
- Added `OllamaProcessState` and `OllamaProcessStatus` to provide a strongly-typed and structured way to track the lifecycle of the Ollama process
- Added `OllamaProcessManagerTests`

This PR introduces the infrastructure and logic but does not yet integrate it into `OllamaService`. Integration will follow in a subsequent PR to keep changes small and reviewable.

To verify the functionality manually, you can temporarily replace the `Main` method in `avallama/Program.cs` with the following snippet (or test several other methods):

```csharp
public static async Task Main(string[] args)  
{  
    const string processName = "ollama";  
  
    var ollamaProcessManager = new OllamaProcessManager();  
    ollamaProcessManager.StatusChanged += OnStatusChanged;  
  
    await ollamaProcessManager.StartAsync();  
    PrintProcesses(processName);  
    await ollamaProcessManager.StopAsync();  
    PrintProcesses(processName);  
}  
  
public static void PrintProcesses(string processName)  
{  
    var processes = Process.GetProcessesByName(processName);  
    if (processes.Length == 0)  
    {        
        Console.WriteLine($"No {processName} found."); 
        return;
    }    
    foreach (var process in processes)  
    {
        Console.WriteLine($"Process found: {process.ProcessName} - {process.Id}");  
    }
}  
  
public static void OnStatusChanged(OllamaProcessStatus processStatus)  
{  
    Console.WriteLine($"Ollama process status: {processStatus.ProcessState.ToString()}");  
}
```