### PR TITLE
Add Ollama API client tests and enrich functionality to `OllamaModel`

### DIFF
--- a/avallama.Tests/Services/OllamaApiClientTests.cs
+++ b/avallama.Tests/Services/OllamaApiClientTests.cs
@@ -86,7 +86,7 @@ public class OllamaApiClientTests : IClassFixture<TestServicesFixture>
         var delayerMock = new TaskDelayerMock(timeMock);
 
         var callCount = 0;
-        var stateEvents = new List<OllamaApiState?>();
+        var stateEvents = new List<OllamaConnectionState?>();
 
         _handlerMock
             .Protected()
@@ -116,12 +116,12 @@ public class OllamaApiClientTests : IClassFixture<TestServicesFixture>
 
         var oac = CreateOllamaApiClient(mockHttpClientFactory.Object, timeMock, delayerMock);
 
-        oac.StatusChanged += status => { stateEvents.Add(status.ApiState); };
+        oac.StatusChanged += status => { stateEvents.Add(status.ConnectionState); };
 
         await oac.CheckConnectionAsync();
 
-        Assert.Equal(1, stateEvents.Count(e => e == OllamaApiState.Connected));
-        Assert.Equal(1, stateEvents.Count(e => e == OllamaApiState.Reconnecting));
+        Assert.Equal(1, stateEvents.Count(e => e == OllamaConnectionState.Connected));
+        Assert.Equal(1, stateEvents.Count(e => e == OllamaConnectionState.Reconnecting));
         Assert.Equal(4, callCount);
         Assert.True(timeMock.Elapsed.TotalMilliseconds >= 100);
     }
@@ -152,14 +152,14 @@ public class OllamaApiClientTests : IClassFixture<TestServicesFixture>
 
         var oac = CreateOllamaApiClient(mockHttpClientFactory.Object, timeMock, delayerMock);
 
-        var stateEvents = new List<OllamaApiState?>();
-        oac.StatusChanged += status => { stateEvents.Add(status.ApiState); };
+        var stateEvents = new List<OllamaConnectionState?>();
+        oac.StatusChanged += status => { stateEvents.Add(status.ConnectionState); };
 
         await oac.CheckConnectionAsync();
 
-        Assert.Equal(OllamaApiState.Connecting, stateEvents[0]);
-        Assert.Equal(OllamaApiState.Reconnecting, stateEvents[1]);
-        Assert.Equal(OllamaApiState.Faulted, stateEvents[2]);
+        Assert.Equal(OllamaConnectionState.Connecting, stateEvents[0]);
+        Assert.Equal(OllamaConnectionState.Reconnecting, stateEvents[1]);
+        Assert.Equal(OllamaConnectionState.Faulted, stateEvents[2]);
         Assert.Equal(3, stateEvents.Count);
         Assert.True(callCount > 1, $"Expected multiple calls, but got {callCount}");
     }
@@ -204,15 +204,15 @@ public class OllamaApiClientTests : IClassFixture<TestServicesFixture>
 
         var oac = CreateOllamaApiClient(mockHttpClientFactory.Object, timeMock, delayerMock);
 
-        var stateEvents = new List<OllamaApiState?>();
-        oac.StatusChanged += status => { stateEvents.Add(status.ApiState); };
+        var stateEvents = new List<OllamaConnectionState?>();
+        oac.StatusChanged += status => { stateEvents.Add(status.ConnectionState); };
 
         await oac.CheckConnectionAsync();
 
         Assert.Equal(2, callCount);
-        Assert.Equal(OllamaApiState.Connecting, stateEvents[0]);
-        Assert.Equal(OllamaApiState.Reconnecting, stateEvents[1]);
-        Assert.Equal(OllamaApiState.Connected, oac.Status.ApiState);
+        Assert.Equal(OllamaConnectionState.Connecting, stateEvents[0]);
+        Assert.Equal(OllamaConnectionState.Reconnecting, stateEvents[1]);
+        Assert.Equal(OllamaConnectionState.Connected, oac.Status.ConnectionState);
     }
 
     [Fact]
@@ -272,24 +272,22 @@ public class OllamaApiClientTests : IClassFixture<TestServicesFixture>
 
         var oac = CreateOllamaApiClient(mockHttpClientFactory.Object, timeMock, delayerMock);
 
-        var stateEvents = new List<OllamaApiState?>();
-        oac.StatusChanged += status => { stateEvents.Add(status.ApiState); };
+        var stateEvents = new List<OllamaConnectionState?>();
+        oac.StatusChanged += status => { stateEvents.Add(status.ConnectionState); };
 
         await oac.CheckConnectionAsync();
 
-        // Act
         var results = new List<OllamaResponse>();
         await foreach (var r in oac.GenerateMessageAsync([], "test-model"))
         {
             results.Add(r);
         }
 
-        // Assert
         Assert.Equal(2, results.Count);
         Assert.Equal("Hello", results[0].Message?.Content);
         Assert.Equal("World!", results[1].Message?.Content);
 
-        Assert.Contains(stateEvents, state => state == OllamaApiState.Connected);
+        Assert.Contains(stateEvents, state => state == OllamaConnectionState.Connected);
     }
 
     [Fact]
@@ -371,15 +369,15 @@ public class OllamaApiClientTests : IClassFixture<TestServicesFixture>
 
         var oac = CreateOllamaApiClient(mockHttpClientFactory.Object, timeMock, delayerMock);
 
-        var stateEvents = new List<OllamaApiState?>();
-        oac.StatusChanged += status => { stateEvents.Add(status.ApiState); };
+        var stateEvents = new List<OllamaConnectionState?>();
+        oac.StatusChanged += status => { stateEvents.Add(status.ConnectionState); };
 
         await foreach (var _ in oac.GenerateMessageAsync([], "model"))
         {
         }
 
-        Assert.Equal(OllamaApiState.Faulted, oac.Status.ApiState);
-        Assert.Contains(OllamaApiState.Faulted, stateEvents);
+        Assert.Equal(OllamaConnectionState.Faulted, oac.Status.ConnectionState);
+        Assert.Contains(OllamaConnectionState.Faulted, stateEvents);
     }
 
     [Fact]
@@ -453,8 +451,8 @@ public class OllamaApiClientTests : IClassFixture<TestServicesFixture>
 
         Assert.Single(results);
         Assert.Equal("Finally loaded!", results[0].Message?.Content);
-        Assert.NotEqual(OllamaApiState.Disconnected, oac.Status.ApiState);
-        Assert.NotEqual(OllamaApiState.Faulted, oac.Status.ApiState);
+        Assert.NotEqual(OllamaConnectionState.Disconnected, oac.Status.ConnectionState);
+        Assert.NotEqual(OllamaConnectionState.Faulted, oac.Status.ConnectionState);
     }
 
     private OllamaApiClient CreateOllamaApiClient(

--- a/avallama.Tests/Services/OllamaApiClientTests.cs
+++ b/avallama.Tests/Services/OllamaApiClientTests.cs
@@ -1,0 +1,476 @@
+// Copyright (c) Márk Csörgő and Martin Bartos
+// Licensed under the MIT License. See LICENSE file for details.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using avallama.Constants.Keys;
+using avallama.Constants.States;
+using avallama.Models.Dtos;
+using avallama.Services.Ollama;
+using avallama.Tests.Fixtures;
+using avallama.Tests.Mocks;
+using avallama.Utilities.Time;
+using Moq;
+using Moq.Protected;
+using Xunit;
+
+namespace avallama.Tests.Services;
+
+public class OllamaApiClientTests : IClassFixture<TestServicesFixture>
+{
+    private readonly TestServicesFixture _fixture;
+    private readonly Mock<HttpMessageHandler> _handlerMock;
+
+    public OllamaApiClientTests(TestServicesFixture fixture)
+    {
+        _fixture = fixture;
+
+        _fixture.ConfigMock
+            .Setup(x => x.ReadSetting(ConfigurationKey.ApiHost))
+            .Returns("localhost");
+
+        _fixture.ConfigMock
+            .Setup(x => x.ReadSetting(ConfigurationKey.ApiPort))
+            .Returns("11434");
+
+        // Create a mock HttpMessageHandler
+        _handlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+
+        // Setup a default SendAsync behavior
+        _handlerMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync((HttpRequestMessage request, CancellationToken _) =>
+            {
+                if (request.RequestUri!.AbsolutePath == "/api/version")
+                {
+                    return new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent("{\"version\":\"1.0.0\"}")
+                    };
+                }
+
+                return new HttpResponseMessage(HttpStatusCode.NotFound);
+            });
+    }
+
+    private Mock<IHttpClientFactory> CreateMockHttpClientFactory(HttpClient checkClient, HttpClient heavyClient)
+    {
+        var mockFactory = new Mock<IHttpClientFactory>();
+
+        mockFactory
+            .Setup(x => x.CreateClient("OllamaCheckHttpClient"))
+            .Returns(checkClient);
+
+        mockFactory
+            .Setup(x => x.CreateClient("OllamaHeavyHttpClient"))
+            .Returns(heavyClient);
+
+        return mockFactory;
+    }
+
+    [Fact]
+    public async Task CheckConnectionAsync_WithDelayedResponse_RetriesConnecting()
+    {
+        var timeMock = new TimeProviderMock();
+        var delayerMock = new TaskDelayerMock(timeMock);
+
+        var callCount = 0;
+        var stateEvents = new List<OllamaApiState?>();
+
+        _handlerMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync((HttpRequestMessage request, CancellationToken _) =>
+            {
+                if (request.RequestUri!.AbsolutePath != "/api/version")
+                    return new HttpResponseMessage(HttpStatusCode.NotFound);
+
+                callCount++; // doesn't need interlocked because it runs synchronously with fake time
+
+                if (callCount < 4)
+                    return new HttpResponseMessage(HttpStatusCode.NotFound);
+
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{\"version\":\"1.0.0\"}")
+                };
+            });
+
+        var httpClient = new HttpClient(_handlerMock.Object);
+        var mockHttpClientFactory = CreateMockHttpClientFactory(httpClient, httpClient);
+
+        var oac = CreateOllamaApiClient(mockHttpClientFactory.Object, timeMock, delayerMock);
+
+        oac.StatusChanged += status => { stateEvents.Add(status.ApiState); };
+
+        await oac.CheckConnectionAsync();
+
+        Assert.Equal(1, stateEvents.Count(e => e == OllamaApiState.Connected));
+        Assert.Equal(1, stateEvents.Count(e => e == OllamaApiState.Reconnecting));
+        Assert.Equal(4, callCount);
+        Assert.True(timeMock.Elapsed.TotalMilliseconds >= 100);
+    }
+
+    [Fact]
+    public async Task CheckConnectionAsync_WhenApiNeverResponds_SetsFaultedStateAfterMaxRetries()
+    {
+        var timeMock = new TimeProviderMock();
+        var delayerMock = new TaskDelayerMock(timeMock);
+
+        var callCount = 0;
+
+        _handlerMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(() =>
+            {
+                callCount++;
+                throw new HttpRequestException("Connection refused");
+            });
+
+        var httpClient = new HttpClient(_handlerMock.Object);
+        var mockHttpClientFactory = CreateMockHttpClientFactory(httpClient, httpClient);
+
+        var oac = CreateOllamaApiClient(mockHttpClientFactory.Object, timeMock, delayerMock);
+
+        var stateEvents = new List<OllamaApiState?>();
+        oac.StatusChanged += status => { stateEvents.Add(status.ApiState); };
+
+        await oac.CheckConnectionAsync();
+
+        Assert.Equal(OllamaApiState.Connecting, stateEvents[0]);
+        Assert.Equal(OllamaApiState.Reconnecting, stateEvents[1]);
+        Assert.Equal(OllamaApiState.Faulted, stateEvents[2]);
+        Assert.Equal(3, stateEvents.Count);
+        Assert.True(callCount > 1, $"Expected multiple calls, but got {callCount}");
+    }
+
+    [Fact]
+    public async Task CheckConnectionAsync_WhenRequestTimeouts_RetriesConnecting()
+    {
+        var callCount = 0;
+
+        var timeMock = new TimeProviderMock();
+        var delayerMock = new TaskDelayerMock(timeMock);
+
+        _handlerMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .Returns((HttpRequestMessage _, CancellationToken _) =>
+            {
+                callCount++;
+
+                if (callCount == 1)
+                {
+                    timeMock.Advance(TimeSpan.FromMilliseconds(50));
+
+                    // simulating a timeout
+                    throw new TaskCanceledException("Request timed out");
+                }
+
+                var response = new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{\"version\":\"1.0.0\"}")
+                };
+
+                return Task.FromResult(response);
+            });
+
+        var httpClient = new HttpClient(_handlerMock.Object);
+        var mockHttpClientFactory = CreateMockHttpClientFactory(httpClient, httpClient);
+
+        var oac = CreateOllamaApiClient(mockHttpClientFactory.Object, timeMock, delayerMock);
+
+        var stateEvents = new List<OllamaApiState?>();
+        oac.StatusChanged += status => { stateEvents.Add(status.ApiState); };
+
+        await oac.CheckConnectionAsync();
+
+        Assert.Equal(2, callCount);
+        Assert.Equal(OllamaApiState.Connecting, stateEvents[0]);
+        Assert.Equal(OllamaApiState.Reconnecting, stateEvents[1]);
+        Assert.Equal(OllamaApiState.Connected, oac.Status.ApiState);
+    }
+
+    [Fact]
+    public async Task GenerateMessageAsync_ReturnsResponses_AndSetsConnectedStatus()
+    {
+        var timeMock = new TimeProviderMock();
+        var delayerMock = new TaskDelayerMock(timeMock);
+
+        var mockHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+
+        var msg1 = new MessageContent
+        {
+            Content = "Hello"
+        };
+        var msg2 = new MessageContent
+        {
+            Content = "World!"
+        };
+
+        var responses = new[]
+        {
+            JsonSerializer.Serialize(new OllamaResponse
+            {
+                Model = "TestLlama", CreatedAt = "2023-08-04T08:52:19.385406455-07:00", Message = msg1, Done = false
+            }),
+            JsonSerializer.Serialize(new OllamaResponse
+            {
+                Model = "TestLlama", CreatedAt = "2023-08-04T08:52:19.385406455-07:00", Message = msg2, Done = false
+            })
+        };
+
+        var responseContent = string.Join("\n", responses);
+
+        mockHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(responseContent)
+            });
+
+        mockHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(r => r.RequestUri!.AbsolutePath.Contains("/api/version")),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
+
+        var httpClient = new HttpClient(mockHandler.Object);
+        var mockHttpClientFactory = CreateMockHttpClientFactory(httpClient, httpClient);
+
+        var oac = CreateOllamaApiClient(mockHttpClientFactory.Object, timeMock, delayerMock);
+
+        var stateEvents = new List<OllamaApiState?>();
+        oac.StatusChanged += status => { stateEvents.Add(status.ApiState); };
+
+        await oac.CheckConnectionAsync();
+
+        // Act
+        var results = new List<OllamaResponse>();
+        await foreach (var r in oac.GenerateMessageAsync([], "test-model"))
+        {
+            results.Add(r);
+        }
+
+        // Assert
+        Assert.Equal(2, results.Count);
+        Assert.Equal("Hello", results[0].Message?.Content);
+        Assert.Equal("World!", results[1].Message?.Content);
+
+        Assert.Contains(stateEvents, state => state == OllamaApiState.Connected);
+    }
+
+    [Fact]
+    public async Task GenerateMessage_InvalidJson_OnlyShowsValid()
+    {
+        var timeMock = new TimeProviderMock();
+        var delayerMock = new TaskDelayerMock(timeMock);
+
+        var mockHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+
+        const string responseContent =
+            "INVALID_JSON\n{\"model\": \"llama3.2\",\"created_at\": \"2023-08-04T08:52:19.385406455-07:00\",\"message\": {\"role\": \"assistant\", \"content\": \"hello\"},\"done\": false}";
+
+        mockHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(responseContent)
+            });
+
+        mockHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(r => r.RequestUri!.AbsolutePath.Contains("/api/version")),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
+
+        var httpClient = new HttpClient(mockHandler.Object);
+        var mockHttpClientFactory = CreateMockHttpClientFactory(httpClient, httpClient);
+
+        var oac = CreateOllamaApiClient(mockHttpClientFactory.Object, timeMock, delayerMock);
+
+        var results = new List<OllamaResponse>();
+        await foreach (var r in oac.GenerateMessageAsync([], "llama3.2"))
+        {
+            results.Add(r);
+        }
+
+        // Only the valid JSON line should be returned
+        Assert.Single(results);
+        Assert.Equal("hello", results[0].Message?.Content);
+    }
+
+    [Fact]
+    public async Task GenerateMessage_WhenConnectionLost_UpdatesStateToFailed()
+    {
+        var timeMock = new TimeProviderMock();
+        var delayerMock = new TaskDelayerMock(timeMock);
+
+        var mockHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+
+        mockHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(r => r.RequestUri!.AbsolutePath.Contains("/api/version")),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
+
+        mockHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(r => r.RequestUri!.AbsolutePath.Contains("/api/chat")),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ThrowsAsync(new HttpRequestException("Connection reset by peer"));
+
+        var httpClient = new HttpClient(mockHandler.Object);
+        var mockHttpClientFactory = CreateMockHttpClientFactory(httpClient, httpClient);
+
+        var oac = CreateOllamaApiClient(mockHttpClientFactory.Object, timeMock, delayerMock);
+
+        var stateEvents = new List<OllamaApiState?>();
+        oac.StatusChanged += status => { stateEvents.Add(status.ApiState); };
+
+        await foreach (var _ in oac.GenerateMessageAsync([], "model"))
+        {
+        }
+
+        Assert.Equal(OllamaApiState.Faulted, oac.Status.ApiState);
+        Assert.Contains(OllamaApiState.Faulted, stateEvents);
+    }
+
+    [Fact]
+    public async Task GenerateMessageAsync_WhenModelLoadIsSlow_ShouldNotTimeout()
+    {
+        var timeMock = new TimeProviderMock();
+        var delayerMock = new TaskDelayerMock(timeMock);
+
+        var mockHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        var msg = new MessageContent { Content = "Finally loaded!" };
+        var responseJson = JsonSerializer.Serialize(new OllamaResponse
+        {
+            Model = "HeavyModel",
+            Message = msg,
+            Done = true
+        });
+
+        mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(r => r.RequestUri!.AbsolutePath.Contains("/api/version")),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
+
+        // slow chat response
+        mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(r => r.RequestUri!.AbsolutePath.Contains("/api/chat")),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .Returns((HttpRequestMessage _, CancellationToken token) =>
+            {
+                // simulating a delay
+                timeMock.Advance(TimeSpan.FromMilliseconds(200));
+
+                var response = new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(responseJson)
+                };
+
+                return Task.FromResult(response);
+            });
+
+        // Create CheckClient with short timeout (simulating fast ping requirement)
+        var checkClient = new HttpClient(mockHandler.Object);
+        checkClient.Timeout = TimeSpan.FromMilliseconds(50);
+
+        // Create HeavyClient with long timeout (simulating patience for model loading)
+        var heavyClient = new HttpClient(mockHandler.Object);
+        heavyClient.Timeout = TimeSpan.FromMilliseconds(500);
+
+        var mockHttpClientFactory = CreateMockHttpClientFactory(checkClient, heavyClient);
+
+        var oac = CreateOllamaApiClient(mockHttpClientFactory.Object, timeMock, delayerMock);
+
+        var results = new List<OllamaResponse>();
+
+        try
+        {
+            await foreach (var r in oac.GenerateMessageAsync([], "heavy-model"))
+            {
+                results.Add(r);
+            }
+        }
+        catch (Exception)
+        {
+            // should not happen if heavyclient is used correctly
+        }
+
+        Assert.Single(results);
+        Assert.Equal("Finally loaded!", results[0].Message?.Content);
+        Assert.NotEqual(OllamaApiState.Disconnected, oac.Status.ApiState);
+        Assert.NotEqual(OllamaApiState.Faulted, oac.Status.ApiState);
+    }
+
+    private OllamaApiClient CreateOllamaApiClient(
+        IHttpClientFactory mockHttpClientFactory,
+        ITimeProvider? timeMock,
+        ITaskDelayer? delayerMock)
+    {
+        return new OllamaApiClient(
+            _fixture.ConfigMock.Object,
+            _fixture.NetworkManagerMock.Object,
+            mockHttpClientFactory,
+            timeMock,
+            delayerMock)
+        {
+            MaxRetryingTime = TimeSpan.FromSeconds(2),
+            ConnectionCheckInterval = TimeSpan.FromMilliseconds(50)
+        };
+    }
+}

--- a/avallama.Tests/Services/OllamaProcessManagerTests.cs
+++ b/avallama.Tests/Services/OllamaProcessManagerTests.cs
@@ -22,18 +22,18 @@ public class OllamaProcessManagerTests : IClassFixture<TestServicesFixture>
         };
 
         var stateChanged = false;
-        var processState = OllamaProcessState.Stopped;
+        var processState = OllamaProcessLifecycle.Stopped;
 
         opm.StatusChanged += status =>
         {
             if (stateChanged) return;
-            processState = status.ProcessState;
+            processState = status.ProcessLifecycle;
             stateChanged = true;
         };
 
         await opm.StartAsync();
 
-        Assert.Equal(OllamaProcessState.Starting, processState);
+        Assert.Equal(OllamaProcessLifecycle.Starting, processState);
     }
 
     [Fact]
@@ -45,11 +45,11 @@ public class OllamaProcessManagerTests : IClassFixture<TestServicesFixture>
             GetProcessesFunc = () => []
         };
 
-        var processState = OllamaProcessState.Stopped;
-        opm.StatusChanged += status => processState = status.ProcessState;
+        var processState = OllamaProcessLifecycle.Stopped;
+        opm.StatusChanged += status => processState = status.ProcessLifecycle;
         await opm.StartAsync();
 
-        Assert.Equal(OllamaProcessState.NotInstalled, processState);
+        Assert.Equal(OllamaProcessLifecycle.NotInstalled, processState);
     }
 
     [Fact]
@@ -61,10 +61,10 @@ public class OllamaProcessManagerTests : IClassFixture<TestServicesFixture>
             GetProcessesFunc = () => [ new OllamaProcessMock() ]
         };
 
-        var processState = OllamaProcessState.Stopped;
-        opm.StatusChanged += status => processState = status.ProcessState;
+        var processState = OllamaProcessLifecycle.Stopped;
+        opm.StatusChanged += status => processState = status.ProcessLifecycle;
         await opm.StartAsync();
 
-        Assert.Equal(OllamaProcessState.Running, processState);
+        Assert.Equal(OllamaProcessLifecycle.Running, processState);
     }
 }

--- a/avallama/Constants/States/OllamaApiState.cs
+++ b/avallama/Constants/States/OllamaApiState.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Márk Csörgő and Martin Bartos
+// Licensed under the MIT License. See LICENSE file for details.
+
+namespace avallama.Constants.States;
+
+/// <summary>
+/// Defines the possible connection states for the Ollama API client.
+/// </summary>
+public enum OllamaApiState
+{
+    /// <summary>
+    /// The client is currently attempting to establish a connection.
+    /// </summary>
+    Connecting,
+
+    /// <summary>
+    /// The client has successfully connected to the Ollama API.
+    /// </summary>
+    Connected,
+
+    /// <summary>
+    /// The client is disconnected from the API.
+    /// </summary>
+    Disconnected,
+
+    /// <summary>
+    /// The client lost connection and is attempting to reconnect automatically.
+    /// </summary>
+    Reconnecting,
+
+    /// <summary>
+    /// The connection failed due to an error (e.g., timeout, unreachable host).
+    /// </summary>
+    Faulted
+}

--- a/avallama/Constants/States/OllamaConnectionState.cs
+++ b/avallama/Constants/States/OllamaConnectionState.cs
@@ -6,7 +6,7 @@ namespace avallama.Constants.States;
 /// <summary>
 /// Defines the possible connection states for the Ollama API client.
 /// </summary>
-public enum OllamaApiState
+public enum OllamaConnectionState
 {
     /// <summary>
     /// The client is currently attempting to establish a connection.

--- a/avallama/Constants/States/OllamaProcessLifecycle.cs
+++ b/avallama/Constants/States/OllamaProcessLifecycle.cs
@@ -6,7 +6,7 @@ namespace avallama.Constants.States;
 /// <summary>
 /// Defines the lifecycle states of the local Ollama executable process.
 /// </summary>
-public enum OllamaProcessState
+public enum OllamaProcessLifecycle
 {
     /// <summary>
     /// The process is currently starting up.

--- a/avallama/Extensions/OllamaModelExtensions.cs
+++ b/avallama/Extensions/OllamaModelExtensions.cs
@@ -1,0 +1,73 @@
+// Copyright (c) Márk Csörgő and Martin Bartos
+// Licensed under the MIT License. See LICENSE file for details.
+
+using System.Collections.Generic;
+using avallama.Constants.Keys;
+using avallama.Models.Dtos;
+using avallama.Models.Ollama;
+
+namespace avallama.Extensions;
+
+public static class OllamaModelExtensions
+{
+    extension(OllamaModel model)
+    {
+        public void EnrichWith(OllamaShowResponse? showResponse)
+        {
+            if (showResponse?.ModelInfo == null) return;
+
+            var workingInfoDirectory = new Dictionary<string, string>(model.Info);
+
+            if (!string.IsNullOrEmpty(showResponse.License))
+            {
+                workingInfoDirectory[ModelInfoKey.License] = showResponse.License;
+            }
+
+            var info = showResponse.ModelInfo;
+            if (!info.TryGetValue("general.architecture", out var archElem) ||
+                !archElem.TryGetString(out var arch) ||
+                string.IsNullOrEmpty(arch))
+            {
+                return;
+            }
+
+            workingInfoDirectory[ModelInfoKey.Architecture] = arch;
+
+            if (info.TryGetValue("general.parameter_count", out var paramElem) &&
+                paramElem.TryGetInt64(out var paramCount) && paramCount > 0)
+            {
+                model.Parameters = paramCount;
+            }
+
+            string[] keys = [ModelInfoKey.BlockCount, ModelInfoKey.ContextLength, ModelInfoKey.EmbeddingLength];
+            foreach (var key in keys)
+            {
+                var searchKey = $"{arch}.{key}";
+                if (info.TryGetValue(searchKey, out var element) && element.TryGetInt32(out var value) && value > 0)
+                {
+                    workingInfoDirectory[key] = value.ToString();
+                }
+            }
+
+            model.Info = workingInfoDirectory;
+        }
+
+        public void EnrichWith(OllamaModelDto? modelDto)
+        {
+            var workingInfoDirectory = new Dictionary<string, string>(model.Info);
+
+            if (modelDto?.Name == null) return;
+            model.Name = modelDto.Name;
+
+            if (modelDto.Size.HasValue) model.Size = modelDto.Size.Value;
+            if (modelDto.Details == null) return;
+
+            if (modelDto.Details.QuantizationLevel != null)
+                workingInfoDirectory[ModelInfoKey.QuantizationLevel] = modelDto.Details.QuantizationLevel;
+            if (modelDto.Details.Format != null)
+                workingInfoDirectory[ModelInfoKey.Format] = modelDto.Details.Format;
+
+            model.Info = workingInfoDirectory;
+        }
+    }
+}

--- a/avallama/Models/Ollama/OllamaApiStatus.cs
+++ b/avallama/Models/Ollama/OllamaApiStatus.cs
@@ -8,14 +8,14 @@ namespace avallama.Models.Ollama;
 /// <summary>
 /// Represents the current status of the Ollama API connection, including state and an optional status message.
 /// </summary>
-/// <param name="apiState">The current state of the API connection.</param>
+/// <param name="connectionState">The current state of the API connection.</param>
 /// <param name="message">An optional message providing details about the state (e.g., error messages).</param>
-public class OllamaApiStatus(OllamaApiState apiState, string? message = null)
+public class OllamaApiStatus(OllamaConnectionState connectionState, string? message = null)
 {
     /// <summary>
     /// Gets or sets the current state of the API connection.
     /// </summary>
-    public OllamaApiState ApiState { get; set; } = apiState;
+    public OllamaConnectionState ConnectionState { get; set; } = connectionState;
 
     /// <summary>
     /// Gets or sets an optional message regarding the status (e.g., error details).

--- a/avallama/Models/Ollama/OllamaApiStatus.cs
+++ b/avallama/Models/Ollama/OllamaApiStatus.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Márk Csörgő and Martin Bartos
+// Licensed under the MIT License. See LICENSE file for details.
+
+using avallama.Constants.States;
+
+namespace avallama.Models.Ollama;
+
+/// <summary>
+/// Represents the current status of the Ollama API connection, including state and an optional status message.
+/// </summary>
+/// <param name="apiState">The current state of the API connection.</param>
+/// <param name="message">An optional message providing details about the state (e.g., error messages).</param>
+public class OllamaApiStatus(OllamaApiState apiState, string? message = null)
+{
+    /// <summary>
+    /// Gets or sets the current state of the API connection.
+    /// </summary>
+    public OllamaApiState ApiState { get; set; } = apiState;
+
+    /// <summary>
+    /// Gets or sets an optional message regarding the status (e.g., error details).
+    /// </summary>
+    public string? Message { get; set; } = message;
+}

--- a/avallama/Models/Ollama/OllamaProcessStatus.cs
+++ b/avallama/Models/Ollama/OllamaProcessStatus.cs
@@ -8,14 +8,14 @@ namespace avallama.Models.Ollama;
 /// <summary>
 /// Represents the current status of the local Ollama process.
 /// </summary>
-/// <param name="processState">The current state of the process.</param>
+/// <param name="processLifecycle">The current state of the process.</param>
 /// <param name="message">An optional message providing details about the state (e.g. error messages).</param>
-public class OllamaProcessStatus(OllamaProcessState processState, string? message = null)
+public class OllamaProcessStatus(OllamaProcessLifecycle processLifecycle, string? message = null)
 {
     /// <summary>
     /// Gets or sets the current state of the local Ollama process.
     /// </summary>
-    public OllamaProcessState ProcessState { get; set; } = processState;
+    public OllamaProcessLifecycle ProcessLifecycle { get; set; } = processLifecycle;
 
     /// <summary>
     /// Gets or sets an optional message regarding the process status.

--- a/avallama/Services/Ollama/OllamaApiClient.cs
+++ b/avallama/Services/Ollama/OllamaApiClient.cs
@@ -15,6 +15,7 @@ using System.Threading.Tasks;
 using avallama.Constants.Keys;
 using avallama.Constants.States;
 using avallama.Exceptions;
+using avallama.Extensions;
 using avallama.Models;
 using avallama.Models.Dtos;
 using avallama.Models.Ollama;
@@ -219,9 +220,8 @@ public class OllamaApiClient(
         if (modelDto == null) return;
         var modelShowResponse = await FetchModelInfoAsync(model.Name);
 
-        // TODO: add missing enrich logic
-        // model.EnrichWith(modelDto);
-        // model.EnrichWith(modelShowResponse);
+        model.EnrichWith(modelDto);
+        model.EnrichWith(modelShowResponse);
     }
 
     public async IAsyncEnumerable<DownloadResponse> PullModelAsync(

--- a/avallama/Services/Ollama/OllamaApiClient.cs
+++ b/avallama/Services/Ollama/OllamaApiClient.cs
@@ -1,0 +1,509 @@
+// Copyright (c) Márk Csörgő and Martin Bartos
+// Licensed under the MIT License. See LICENSE file for details.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using avallama.Constants.Keys;
+using avallama.Constants.States;
+using avallama.Exceptions;
+using avallama.Models;
+using avallama.Models.Dtos;
+using avallama.Models.Ollama;
+using avallama.Services.Persistence;
+using avallama.Utilities.Network;
+using avallama.Utilities.Time;
+
+namespace avallama.Services.Ollama;
+
+/// <summary>
+/// Delegate for handling changes in the Ollama API connection status.
+/// </summary>
+public delegate void OllamaApiStatusChangedHandler(OllamaApiStatus status);
+
+/// <summary>
+/// Defines the contract for interacting with the Ollama API, including connection management,
+/// model retrieval, generation, and deletion.
+/// </summary>
+public interface IOllamaApiClient
+{
+    #region Interface
+
+    /// <summary>
+    /// Gets the current status of the connection to the Ollama API.
+    /// </summary>
+    OllamaApiStatus Status { get; }
+
+    /// <summary>
+    /// Event raised when the API connection status changes.
+    /// </summary>
+    event OllamaApiStatusChangedHandler? StatusChanged;
+
+    /// <summary>
+    /// Checks the connection to the Ollama API and updates the status accordingly.
+    /// </summary>
+    Task CheckConnectionAsync();
+
+    /// <summary>
+    /// Attempts to reconnect to the Ollama API within a configured timeout period.
+    /// </summary>
+    Task RetryConnectionAsync();
+
+    /// <summary>
+    /// Enriches the specified model with detailed information from the API (/api/tags, /api/show).
+    /// </summary>
+    /// <param name="model">The model to enrich.</param>
+    Task EnrichModelAsync(OllamaModel model);
+
+    /// <summary>
+    /// Retrieves a list of models that are currently downloaded and available on the Ollama server.
+    /// </summary>
+    /// <returns>A list of downloaded models.</returns>
+    Task<IList<OllamaModel>> GetDownloadedModelsAsync();
+
+    /// <summary>
+    /// Deletes a specific model from the Ollama server.
+    /// </summary>
+    /// <param name="modelName">The name of the model to delete.</param>
+    /// <returns>True if the deletion was successful; otherwise, false.</returns>
+    Task<bool> DeleteModelAsync(string modelName);
+
+    /// <summary>
+    /// Pulls a model from the Ollama library, streaming the download progress.
+    /// </summary>
+    /// <param name="modelName">The name of the model to download.</param>
+    /// <param name="ct">Cancellation token to cancel the operation.</param>
+    /// <returns>An async stream of download progress updates.</returns>
+    IAsyncEnumerable<DownloadResponse> PullModelAsync(string modelName, CancellationToken ct = default);
+
+    /// <summary>
+    /// Generates a chat response from the specified model based on the message history.
+    /// </summary>
+    /// <param name="messageHistory">The history of messages in the conversation.</param>
+    /// <param name="modelName">The name of the model to use for generation.</param>
+    /// <param name="ct">Cancellation token to cancel the operation.</param>
+    /// <returns>An async stream of response chunks.</returns>
+    IAsyncEnumerable<OllamaResponse> GenerateMessageAsync(List<Message> messageHistory, string modelName,
+        CancellationToken ct = default);
+
+    #endregion
+}
+
+/// <summary>
+/// Implementation of the Ollama API client, handling HTTP communication with the Ollama server.
+/// </summary>
+public class OllamaApiClient(
+    IConfigurationService configurationService,
+    INetworkManager networkManager,
+    IHttpClientFactory httpClientFactory,
+    ITimeProvider? timeProvider = null,
+    ITaskDelayer? taskDelayer = null)
+    : IOllamaApiClient
+{
+    #region Constants & Fields
+
+    // Default server configuration
+    public const int DefaultApiPort = 11434;
+    public const string DefaultApiHost = "localhost";
+
+    // Dependencies
+    private readonly HttpClient _checkHttpClient = httpClientFactory.CreateClient("OllamaCheckHttpClient");
+    private readonly HttpClient _heavyHttpClient = httpClientFactory.CreateClient("OllamaHeavyHttpClient");
+    private readonly ITimeProvider _timeProvider = timeProvider ?? new RealTimeProvider();
+    private readonly ITaskDelayer _taskDelayer = taskDelayer ?? new RealTaskDelayer();
+
+    // Configuration
+    private readonly TimeSpan _downloadTimeout = TimeSpan.FromSeconds(5);
+    public TimeSpan MaxRetryingTime { get; init; } = TimeSpan.FromSeconds(15);
+    public TimeSpan ConnectionCheckInterval { get; init; } = TimeSpan.FromMilliseconds(500);
+
+    private readonly JsonSerializerOptions _jsonSerializerOptions = new() { PropertyNameCaseInsensitive = true };
+
+    #endregion
+
+    #region Event & Status
+
+    public event OllamaApiStatusChangedHandler? StatusChanged;
+
+    public OllamaApiStatus Status
+    {
+        get;
+        private set
+        {
+            if (field == value) return;
+            field = value;
+            StatusChanged?.Invoke(value);
+        }
+    } = new(OllamaApiState.Disconnected);
+
+    #endregion
+
+    #region Public Methods
+
+    public async Task CheckConnectionAsync()
+    {
+        Status = new OllamaApiStatus(OllamaApiState.Connecting);
+        if (await IsOllamaReachable())
+        {
+            Status = new OllamaApiStatus(OllamaApiState.Connected);
+        }
+        else
+        {
+            await RetryConnectionAsync();
+        }
+    }
+
+    public async Task RetryConnectionAsync()
+    {
+        Status = new OllamaApiStatus(OllamaApiState.Reconnecting);
+        _timeProvider.Start();
+
+        var loopStartTime = _timeProvider.Elapsed;
+        while (_timeProvider.Elapsed - loopStartTime < MaxRetryingTime)
+        {
+            if (await IsOllamaReachable())
+            {
+                Status = new OllamaApiStatus(OllamaApiState.Connected);
+                return;
+            }
+
+            await _taskDelayer.Delay(ConnectionCheckInterval);
+        }
+
+        SetUnreachableStatus();
+    }
+
+    public async Task<IList<OllamaModel>> GetDownloadedModelsAsync()
+    {
+        if (!await IsOllamaReachable())
+        {
+            SetUnreachableStatus();
+            return [];
+        }
+
+        var tagsResponse = await FetchOllamaTagsAsync();
+
+        var downloadedModels = tagsResponse?.Models
+            .Where(dto => !string.IsNullOrEmpty(dto.Name))
+            .Select(dto => new OllamaModel
+            {
+                Name = dto.Name!,
+                Info = new Dictionary<string, string>()
+            }).ToList();
+
+        return downloadedModels ?? [];
+    }
+
+    public async Task EnrichModelAsync(OllamaModel model)
+    {
+        if (string.IsNullOrEmpty(model.Name)) return;
+
+        if (!await IsOllamaReachable())
+        {
+            SetUnreachableStatus();
+            return;
+        }
+
+        var tagsResponse = await FetchOllamaTagsAsync();
+
+        var modelDto = tagsResponse?.Models.FirstOrDefault(modelDto => model.Name == modelDto.Name);
+
+        if (modelDto == null) return;
+        var modelShowResponse = await FetchModelInfoAsync(model.Name);
+
+        // TODO: add missing enrich logic
+        // model.EnrichWith(modelDto);
+        // model.EnrichWith(modelShowResponse);
+    }
+
+    public async IAsyncEnumerable<DownloadResponse> PullModelAsync(
+        string modelName,
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        if (!await IsOllamaReachable())
+        {
+            SetUnreachableStatus();
+            throw NewServiceUnreachableException();
+        }
+
+        var payload = new { model = modelName, stream = true };
+        var jsonPayload = JsonSerializer.Serialize(payload);
+        var content = new StringContent(jsonPayload, Encoding.UTF8, "application/json");
+
+        using var request = CreateRequest(HttpMethod.Post, "/api/pull");
+        request.Content = content;
+
+        HttpResponseMessage? response;
+        try
+        {
+            // Using check client since this request is sent once and associated with the stream.
+            // It doesn't need heavyclient's full timeout, as the API should reply quickly at first.
+            response = await _checkHttpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct);
+        }
+        catch (HttpRequestException ex)
+        {
+            SetUnreachableStatus();
+            throw NewServiceUnreachableException(ex);
+        }
+
+        if (response.StatusCode == HttpStatusCode.OK)
+        {
+            Status = new OllamaApiStatus(OllamaApiState.Connected);
+        }
+        else
+        {
+            throw new OllamaApiException(response.StatusCode);
+        }
+
+        // TODO: Extract stream reading logic into a separate method so proper exceptions will be thrown
+        // and they'll be canceled correctly.
+        // TODO: Handle the thrown exceptions properly (e.g., catch LostInternetException in HomeViewModel).
+
+        await using var stream = await response.Content.ReadAsStreamAsync(ct);
+        using var reader = new StreamReader(stream);
+        var lastProgressDateTime = DateTime.Now;
+        long? previousCompletedValue = 0;
+
+        while (!ct.IsCancellationRequested)
+        {
+            DownloadResponse? json = null;
+            try
+            {
+                // Check for internet connection if the timeout has passed without progress
+                if (DateTime.Now - lastProgressDateTime > _downloadTimeout)
+                {
+                    if (!await networkManager.IsInternetAvailableAsync())
+                    {
+                        throw new LostInternetConnectionException();
+                    }
+                }
+
+                var line = await reader.ReadLineAsync(ct);
+                if (line != null)
+                {
+                    json = JsonSerializer.Deserialize<DownloadResponse>(line, _jsonSerializerOptions);
+
+                    // Check whether the Completed value is received and is increasing
+                    if (json is { Completed: not null } && json.Completed > previousCompletedValue)
+                    {
+                        lastProgressDateTime = DateTime.Now;
+                        previousCompletedValue = json.Completed;
+                    }
+                }
+                else break;
+            }
+            catch (JsonException)
+            {
+                // TODO: Proper logging
+            }
+
+            if (json != null) yield return json;
+        }
+    }
+
+    public async IAsyncEnumerable<OllamaResponse> GenerateMessageAsync(
+        List<Message> messageHistory,
+        string modelName,
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        // TODO: Pass cancellation token properly when supporting stopping message generation.
+        // The default token currently is not cancellable.
+
+        if (!await IsOllamaReachable())
+        {
+            SetUnreachableStatus();
+            yield break;
+        }
+
+        var chatRequest = new ChatRequest(messageHistory, modelName);
+        var jsonPayload = chatRequest.ToJson();
+        var content = new StringContent(jsonPayload, Encoding.UTF8, "application/json");
+
+        using var request = CreateRequest(HttpMethod.Post, "/api/chat");
+        request.Content = content;
+
+        HttpResponseMessage response;
+        try
+        {
+            response = await _heavyHttpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct);
+            if (response.StatusCode == HttpStatusCode.OK)
+            {
+                Status = new OllamaApiStatus(OllamaApiState.Connected);
+            }
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
+        {
+            SetUnreachableStatus();
+            yield break;
+        }
+
+        await using var stream = await response.Content.ReadAsStreamAsync(ct);
+        using var reader = new StreamReader(stream);
+        while (await reader.ReadLineAsync(ct) is { } line)
+        {
+            if (string.IsNullOrWhiteSpace(line)) continue;
+            OllamaResponse? json = null;
+            try
+            {
+                json = JsonSerializer.Deserialize<OllamaResponse>(line);
+            }
+            catch (JsonException)
+            {
+                // TODO: Proper logging
+            }
+
+            if (json != null) yield return json;
+        }
+    }
+
+    public async Task<bool> DeleteModelAsync(string modelName)
+    {
+        if (!await IsOllamaReachable())
+        {
+            SetUnreachableStatus();
+            return false;
+        }
+
+        var payload = new { model = modelName };
+        var jsonPayload = JsonSerializer.Serialize(payload);
+        var content = new StringContent(jsonPayload, Encoding.UTF8, "application/json");
+
+        using var request = CreateRequest(HttpMethod.Delete, "/api/delete");
+        request.Content = content;
+
+        // Using check client since API should not take a long time on this
+        using var response = await _checkHttpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
+        return response.StatusCode == HttpStatusCode.OK;
+    }
+
+    /// <summary>
+    /// Checks if the configured API host points to a remote server.
+    /// </summary>
+    /// <param name="host">The hostname to check.</param>
+    /// <returns>True if the Ollama connection is remote; otherwise, false.</returns>
+    public static bool IsConnectionRemote(string host)
+    {
+        if (string.IsNullOrEmpty(host)) return false;
+
+        return !host.Equals("localhost", StringComparison.OrdinalIgnoreCase) &&
+               !host.Equals("127.0.0.1", StringComparison.Ordinal);
+    }
+
+    #endregion
+
+    #region Private Helpers
+
+    /// <summary>
+    /// Creates the appropriate exception based on whether the connection is local or remote.
+    /// </summary>
+    /// <returns>A newly created OllamaException to throw.</returns>
+    private OllamaException NewServiceUnreachableException(Exception? innerException = null)
+    {
+        if (IsConnectionRemote(configurationService.ReadSetting(ConfigurationKey.ApiHost)))
+        {
+            return new OllamaRemoteServerUnreachableException(innerException);
+        }
+
+        return new OllamaLocalServerUnreachableException(innerException);
+    }
+
+    private void SetUnreachableStatus()
+    {
+        if (IsConnectionRemote(configurationService.ReadSetting(ConfigurationKey.ApiHost)))
+        {
+            Status = new OllamaApiStatus(OllamaApiState.Faulted,
+                LocalizationService.GetString("OLLAMA_REMOTE_UNREACHABLE"));
+        }
+        else
+        {
+            Status = new OllamaApiStatus(OllamaApiState.Faulted,
+                LocalizationService.GetString("OLLAMA_LOCAL_UNREACHABLE"));
+        }
+    }
+
+    /// <summary>
+    /// Creates an HttpRequestMessage with the correct base URI derived from the configuration.
+    /// </summary>
+    private HttpRequestMessage CreateRequest(HttpMethod method, string endpoint)
+    {
+        var host = configurationService.ReadSetting(ConfigurationKey.ApiHost);
+        if (string.IsNullOrEmpty(host) || host == "localhost")
+        {
+            // Use IPv4 since Windows may resolve 'localhost' to IPv6
+            host = "127.0.0.1";
+        }
+
+        var port = configurationService.ReadSetting(ConfigurationKey.ApiPort);
+        if (string.IsNullOrEmpty(port)) port = "11434";
+
+        var builder = new UriBuilder("http", host, int.Parse(port), endpoint);
+
+        return new HttpRequestMessage(method, builder.Uri);
+    }
+
+    private async Task<OllamaTagsResponse?> FetchOllamaTagsAsync()
+    {
+        try
+        {
+            using var request = CreateRequest(HttpMethod.Get, "/api/tags");
+            using var response = await _checkHttpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
+            var json = await response.Content.ReadAsStringAsync();
+            return JsonSerializer.Deserialize<OllamaTagsResponse>(json, _jsonSerializerOptions);
+        }
+        catch (Exception ex) when (ex is HttpRequestException)
+        {
+            // TODO: Proper logging
+            return null;
+        }
+    }
+
+    private async Task<OllamaShowResponse?> FetchModelInfoAsync(string modelName)
+    {
+        try
+        {
+            var payload = new { model = modelName };
+            var jsonPayload = JsonSerializer.Serialize(payload);
+            var content = new StringContent(jsonPayload, Encoding.UTF8, "application/json");
+
+            using var request = CreateRequest(HttpMethod.Post, "/api/show");
+            request.Content = content;
+
+            // Using check client since API should not take a long time on this
+            using var response = await _checkHttpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
+            var json = await response.Content.ReadAsStringAsync();
+
+            return JsonSerializer.Deserialize<OllamaShowResponse>(json, _jsonSerializerOptions);
+        }
+        catch (Exception ex) when (ex is HttpRequestException)
+        {
+            // TODO: Proper logging
+            return null;
+        }
+    }
+
+    private async Task<bool> IsOllamaReachable()
+    {
+        try
+        {
+            using var request = CreateRequest(HttpMethod.Get, "/api/version");
+            using var response =
+                await _checkHttpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
+
+            return response.StatusCode == HttpStatusCode.OK;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    #endregion
+}


### PR DESCRIPTION
### Changes
- Added tests for api client as `OllamaApiClientTests` (these test cases are used up from `OllamaService`, so nothing new added, only a separation of concerns)
- Added enrich functionality as extensions which allow to add information from `/api/tags` and `/api/show` to `OllamaModel` objects