### PR TITLE
Queue service and versioning fixes + add documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,53 +23,61 @@ This project is currently being developed by Márk Csörgő and Martin Bartos.
 
 ## Features
 
--  **Seamless Local LLMs** - Chat seamlessly with LLMs hosted locally on your machine
--  **Your Data Stays With You** - Chats are saved to your machine, ensuring your data privacy
--  **Ollama On The Network** – Connect the app to an Ollama instance on your network to easily use your AI workstation on any device
--  **Multi-Platform Support** – Runs on Windows, Linux and macOS utilizing the Avalonia framework
--  **Lightweight and Efficient** – Designed to be minimal while providing a smooth experience
--  **Automatic Ollama Process Management** – Ensures Ollama runs efficiently in the background without manual intervention
+- **Seamless Local LLMs** - Chat seamlessly with LLMs hosted locally on your machine
+- **Your Data Stays With You** - Chats are saved to your machine, ensuring your data privacy
+- **Ollama On The Network** – Connect the app to an Ollama instance on your network to easily use your AI workstation on
+  any device
+- **Multi-Platform Support** – Runs on Windows, Linux and macOS utilizing the Avalonia framework
+- **Lightweight and Efficient** – Designed to be minimal while providing a smooth experience
+- **Automatic Ollama Process Management** – Ensures Ollama runs efficiently in the background without manual
+  intervention
 
 ## Contributions
 
-We are currently not accepting outside contributions, however we encourage users to report bugs, crashes or any unexpected behaviour. Please see our [Contribution Guidelines](./CONTRIBUTING.md) for more information.
-
+We are currently not accepting outside contributions, however we encourage users to report bugs, crashes or any
+unexpected behaviour. Please see our [Contribution Guidelines](./CONTRIBUTING.md) for more information.
 
 ## Installation
 
-**Important notice**: a working installation of Ollama is required for Avallama to work properly. Before installing Avallama on any platform, please download and install Ollama from [this link](https://ollama.com/download).
+**Important notice**: a working installation of Ollama is required for Avallama to work properly. Before installing
+Avallama on any platform, please download and install Ollama from [this link](https://ollama.com/download).
 
-### Linux
+### Debian/Ubuntu (x64)
 
-#### Debian/Ubuntu (x64)
 1. Download the latest .deb package from the [releases](https://github.com/4foureyes/avallama/releases) page.
 2. Open a terminal and navigate to the directory where the file was downloaded, for example:
+
 ```bash
 cd ~/Downloads
 ```
+
 3. Install the package using the following command:
+
 ```bash
 sudo apt install ./avallama_0.2.0_amd64.deb
 ```
+
 *Replace `./avallama_0.2.0_amd64.deb` with the correct filename of the latest package*
 
 4. After that, you can run the application from the application menu or with the `avallama` command
 
 To uninstall, run:
+
 ```bash
 sudo apt remove avallama
 ```
 
-#### Arch Linux (x64)
+### Arch Linux (x64)
 
 1. Download the latest .pkg.tar.zst from the Releases tab
 2. Open a terminal and navigate to the directory where the file was downloaded.
 3. Install the package using the following command:
+
 ```bash
 sudo pacman -U avallama-0.2.0-1-x86_64.pkg.tar.zst
 ```
-*Replace `avallama-0.2.0-1-x86_64.pkg.tar.zst` with the correct filename of the latest package*
 
+*Replace `avallama-0.2.0-1-x86_64.pkg.tar.zst` with the correct filename of the latest package*
 
 To uninstall run:
 
@@ -78,52 +86,60 @@ sudo pacman -R avallama
 ```
 
 To uninstall and remove config files
+
 ```bash
 sudo pacman -Rns avallama
 ```
 
 ### Windows (x64)
 
-The Windows installer is **not signed with a trusted code-signing certificate**, so Windows SmartScreen may prevent it from running. If you wish to circumvent this, click `More info -> Run anyway`.
+The Windows installer is **not signed with a trusted code-signing certificate**, so Windows SmartScreen may prevent it
+from running. If you wish to circumvent this, click `More info -> Run anyway`.
 
-1. Download the latest Windows installer from the [releases](https://github.com/4foureyes/avallama/releases) page, e.g. `avallama-setup-0.2.0.exe`.
+1. Download the latest Windows installer from the [releases](https://github.com/4foureyes/avallama/releases) page, e.g.
+   `avallama-setup-0.3.0.exe`.
 2. Open the installer and go through the setup steps.
 3. Once installed, you can run the application from the Start Menu.
 
-To uninstall, remove it through the `Apps > Installed apps` page in Settings, or navigate to the installation directory and run unins000.exe.
+To uninstall, remove it through the `Apps > Installed apps` page in Settings, or navigate to the installation directory
+and run unins000.exe.
 
-### Windows (arm64)
-
-Windows on Arm is not currently supported.
-
-### macOS
+### macOS (x64 and arm64)
 
 This application is **not signed nor notarized**. MacOS may prevent it from running by default.
 
-1. Download the latest `.dmg` file from the [releases](https://github.com/4foureyes/avallama/releases) page. (for Intel use *osx_x64*, for Apple Silicon use *osx_arm64*)
+1. Download the latest `.dmg` file from the [releases](https://github.com/4foureyes/avallama/releases) page. (for Intel
+   use *osx_x64*, for Apple Silicon use *osx_arm64*)
 2. Open the downloaded `.dmg` file.
 3. Drag **Avallama** into the **Applications** folder.
 
-If the '*app is damaged or can't be opened*' error occurs, make sure you remove the quarantine flag using the following command in the Terminal:
+If the '*app is damaged or can't be opened*' error occurs, make sure you remove the quarantine flag using the following
+command in the Terminal:
+
 ```bash
 xattr -cr /Applications/Avallama.app
 ```
 
 ### Building from source
 
-If you are comfortable building the app from source, feel free to clone the repository and build the application to test out the newest features we are actively implementing.
+If you are comfortable building the app from source, feel free to clone the repository and build the application to test
+out the newest features we are actively implementing.
 
 1. Install the [.NET SDK](https://dotnet.microsoft.com/en-us/download) (version 10.0 or later).
 2. Clone the repository: `git clone https://github.com/4foureyes/avallama.git`
 3. Navigate to the project directory: `cd avallama`
 4. Restore dependencies: `dotnet restore`
 5. Build the project: `dotnet build -c Release`
-6. Run the application: `dotnet run -c Release --project avallama/avallama.csproj`
-7. (Optional) To create a self-contained publish for your platform, run:
+6. (macOS only) Build native dependencies:
+   `clang -dynamiclib -framework Cocoa -arch x86_64 -arch arm64 -o avallama/bin/Release/net10.0/libFullScreenCheck.dylib native/macos/FullScreenCheck.m`
+7. Run the application: `dotnet run -c Release --project avallama/avallama.csproj`
+8. (Optional) To create a self-contained publish for your platform, run:
+
 ```bash
 dotnet publish -c Release -r <RID> --self-contained true
 ```
-The output executable will be located in the `avallama/bin/Release/net9.0/<RID>/publish/` directory.
+
+The output executable will be located in the `avallama/bin/Release/net10.0/<RID>/publish/` directory.
 
 *Replace `<RID>` with your platform's Runtime Identifier, e.g. `win-x64`, `linux-x64`, `osx-arm64`, `osx-x64`*
 

--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@ cd ~/Downloads
 3. Install the package using the following command:
 
 ```bash
-sudo apt install ./avallama_0.2.0_amd64.deb
+sudo apt install ./avallama_0.3.0_amd64.deb
 ```
 
-*Replace `./avallama_0.2.0_amd64.deb` with the correct filename of the latest package*
+*Replace `./avallama_0.3.0_amd64.deb` with the correct filename of the latest package*
 
 4. After that, you can run the application from the application menu or with the `avallama` command
 
@@ -71,10 +71,10 @@ sudo apt remove avallama
 3. Install the package using the following command:
 
 ```bash
-sudo pacman -U avallama-0.2.0-1-x86_64.pkg.tar.zst
+sudo pacman -U avallama-0.3.0-1-x86_64.pkg.tar.zst
 ```
 
-*Replace `avallama-0.2.0-1-x86_64.pkg.tar.zst` with the correct filename of the latest package*
+*Replace `avallama-0.3.0-1-x86_64.pkg.tar.zst` with the correct filename of the latest package*
 
 To uninstall run:
 

--- a/README.md
+++ b/README.md
@@ -25,24 +25,21 @@ This project is currently being developed by Márk Csörgő and Martin Bartos.
 
 - **Seamless Local LLMs** - Chat seamlessly with LLMs hosted locally on your machine
 - **Your Data Stays With You** - Chats are saved to your machine, ensuring your data privacy
-- **Ollama On The Network** – Connect the app to an Ollama instance on your network to easily use your AI workstation on
-  any device
+- **Ollama On The Network** – Connect the app to an Ollama instance on your network to easily use your AI workstation on any device
 - **Multi-Platform Support** – Runs on Windows, Linux and macOS utilizing the Avalonia framework
 - **Lightweight and Efficient** – Designed to be minimal while providing a smooth experience
-- **Automatic Ollama Process Management** – Ensures Ollama runs efficiently in the background without manual
-  intervention
+- **Automatic Ollama Process Management** – Ensures Ollama runs efficiently in the background without manual intervention
 
 ## Contributions
 
-We are currently not accepting outside contributions, however we encourage users to report bugs, crashes or any
-unexpected behaviour. Please see our [Contribution Guidelines](./CONTRIBUTING.md) for more information.
+We are currently not accepting outside contributions, however we encourage users to report bugs, crashes or any unexpected behaviour. Please see our [Contribution Guidelines](./CONTRIBUTING.md) for more information.
 
 ## Installation
 
-**Important notice**: a working installation of Ollama is required for Avallama to work properly. Before installing
-Avallama on any platform, please download and install Ollama from [this link](https://ollama.com/download).
+**Important notice**: a working installation of Ollama is required for Avallama to work properly. Before installing Avallama on any platform, please download and install Ollama from [this link](https://ollama.com/download).
 
-### Debian/Ubuntu (x64)
+### Linux
+#### Debian/Ubuntu (x64)
 
 1. Download the latest .deb package from the [releases](https://github.com/4foureyes/avallama/releases) page.
 2. Open a terminal and navigate to the directory where the file was downloaded, for example:
@@ -67,9 +64,9 @@ To uninstall, run:
 sudo apt remove avallama
 ```
 
-### Arch Linux (x64)
+#### Arch Linux (x64)
 
-1. Download the latest .pkg.tar.zst from the Releases tab
+1. Download the latest .pkg.tar.zst from the Releases tab.
 2. Open a terminal and navigate to the directory where the file was downloaded.
 3. Install the package using the following command:
 
@@ -93,55 +90,31 @@ sudo pacman -Rns avallama
 
 ### Windows (x64)
 
-The Windows installer is **not signed with a trusted code-signing certificate**, so Windows SmartScreen may prevent it
-from running. If you wish to circumvent this, click `More info -> Run anyway`.
+The Windows installer is **not signed with a trusted code-signing certificate**, so Windows SmartScreen may prevent it from running. If you wish to circumvent this, click `More info -> Run anyway`.
 
-1. Download the latest Windows installer from the [releases](https://github.com/4foureyes/avallama/releases) page, e.g.
-   `avallama-setup-0.3.0.exe`.
+1. Download the latest Windows installer from the [releases](https://github.com/4foureyes/avallama/releases) page, e.g. `avallama-setup-0.3.0.exe`.
 2. Open the installer and go through the setup steps.
 3. Once installed, you can run the application from the Start Menu.
 
-To uninstall, remove it through the `Apps > Installed apps` page in Settings, or navigate to the installation directory
-and run unins000.exe.
+To uninstall, remove it through the `Apps > Installed apps` page in Settings, or navigate to the installation directory and run unins000.exe.
 
 ### macOS (x64 and arm64)
 
 This application is **not signed nor notarized**. MacOS may prevent it from running by default.
 
-1. Download the latest `.dmg` file from the [releases](https://github.com/4foureyes/avallama/releases) page. (for Intel
-   use *osx_x64*, for Apple Silicon use *osx_arm64*)
+1. Download the latest `.dmg` file from the [releases](https://github.com/4foureyes/avallama/releases) page. (for Intel use *osx_x64*, for Apple Silicon use *osx_arm64*)
 2. Open the downloaded `.dmg` file.
 3. Drag **Avallama** into the **Applications** folder.
 
-If the '*app is damaged or can't be opened*' error occurs, make sure you remove the quarantine flag using the following
-command in the Terminal:
+If the '*app is damaged or can't be opened*' error occurs, make sure you remove the quarantine flag using the following command in the Terminal:
 
 ```bash
 xattr -cr /Applications/Avallama.app
 ```
 
-### Building from source
+## Building from source
 
-If you are comfortable building the app from source, feel free to clone the repository and build the application to test
-out the newest features we are actively implementing.
-
-1. Install the [.NET SDK](https://dotnet.microsoft.com/en-us/download) (version 10.0 or later).
-2. Clone the repository: `git clone https://github.com/4foureyes/avallama.git`
-3. Navigate to the project directory: `cd avallama`
-4. Restore dependencies: `dotnet restore`
-5. Build the project: `dotnet build -c Release`
-6. (macOS only) Build native dependencies:
-   `clang -dynamiclib -framework Cocoa -arch x86_64 -arch arm64 -o avallama/bin/Release/net10.0/libFullScreenCheck.dylib native/macos/FullScreenCheck.m`
-7. Run the application: `dotnet run -c Release --project avallama/avallama.csproj`
-8. (Optional) To create a self-contained publish for your platform, run:
-
-```bash
-dotnet publish -c Release -r <RID> --self-contained true
-```
-
-The output executable will be located in the `avallama/bin/Release/net10.0/<RID>/publish/` directory.
-
-*Replace `<RID>` with your platform's Runtime Identifier, e.g. `win-x64`, `linux-x64`, `osx-arm64`, `osx-x64`*
+Build instructions are available [here](https://github.com/4foureyes/avallama/wiki/Building-from-source).
 
 ## Known issues
 

--- a/avallama.Tests/Services/UpdateServiceTests.cs
+++ b/avallama.Tests/Services/UpdateServiceTests.cs
@@ -84,7 +84,7 @@ public class UpdateServiceTests
     public async Task IsUpdateAvailableAsync_SameVersion_ReturnsFalse()
     {
         _networkManagerMock.Setup(x => x.IsInternetAvailableAsync()).ReturnsAsync(true);
-        const string currentVersion = App.Version;
+        var currentVersion = App.Version;
         var json = JsonSerializer.Serialize(new { tag_name = currentVersion });
         SetupHttpResponse(HttpStatusCode.OK, json);
         var service = CreateService();

--- a/avallama/App.axaml.cs
+++ b/avallama/App.axaml.cs
@@ -27,7 +27,7 @@ public partial class App : Application
     private DialogService? _dialogService;
     private DatabaseInitService? _databaseInitService;
     public static SqliteConnection SharedDbConnection { get; private set; } = null!;
-    public const string Version = "v0.3.0";
+    public static readonly Version Version = new (0, 3, 1);
 
     public override void Initialize()
     {

--- a/avallama/Constants/QueueItemCancellationReason.cs
+++ b/avallama/Constants/QueueItemCancellationReason.cs
@@ -3,10 +3,28 @@
 
 namespace avallama.Constants;
 
+/// <summary>
+/// Specifies the reasons why a <see cref="avallama.Models.QueueItem"/> might be canceled.
+/// </summary>
 public enum QueueItemCancellationReason
 {
+    /// <summary>
+    /// The cancellation reason is unknown or not specified.
+    /// </summary>
     Unknown,
+
+    /// <summary>
+    /// The item was canceled due to an explicit user request.
+    /// </summary>
     UserCancelRequest,
+
+    /// <summary>
+    /// The item was canceled because the user paused the operation.
+    /// </summary>
     UserPauseRequest,
+
+    /// <summary>
+    /// The item was canceled automatically by the system to scale down parallelism.
+    /// </summary>
     SystemScaling
 }

--- a/avallama/Constants/States/DownloadState.cs
+++ b/avallama/Constants/States/DownloadState.cs
@@ -3,12 +3,38 @@
 
 namespace avallama.Constants.States;
 
+/// <summary>
+/// Represents the various states a model download can be during its lifecycle.
+/// </summary>
 public enum DownloadState
 {
+    /// <summary>
+    /// The model is available for download but has not been queued yet.
+    /// </summary>
     Downloadable,
+
+    /// <summary>
+    /// The download request is waiting in the queue to be processed.
+    /// </summary>
     Queued,
+
+    /// <summary>
+    /// The model is currently being downloaded.
+    /// </summary>
     Downloading,
+
+    /// <summary>
+    /// The download process has been paused by the user.
+    /// </summary>
     Paused,
+
+    /// <summary>
+    /// The model has been successfully downloaded and is ready for use.
+    /// </summary>
     Downloaded,
+
+    /// <summary>
+    /// The download process encountered an error and failed.
+    /// </summary>
     Failed
 }

--- a/avallama/Models/Download/ModelDownloadRequest.cs
+++ b/avallama/Models/Download/ModelDownloadRequest.cs
@@ -6,14 +6,43 @@ using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace avallama.Models.Download;
 
+/// <summary>
+/// Represents a queue item specific to downloading an Ollama model.
+/// </summary>
 public partial class ModelDownloadRequest : QueueItem
 {
+    /// <summary>
+    /// Gets the name of the model to be downloaded.
+    /// </summary>
     public required string ModelName { get; init; }
+
+    /// <summary>
+    /// Gets the utility used to calculate the real-time download speed.
+    /// </summary>
     public NetworkSpeedCalculator SpeedCalculator { get; } = new();
+
+    /// <summary>
+    /// Gets or sets the number of parts this download has been split into.
+    /// </summary>
     public int DownloadPartCount { get; set; }
 
+    /// <summary>
+    /// The total number of bytes successfully downloaded so far.
+    /// </summary>
     [ObservableProperty] private long _downloadedBytes;
+
+    /// <summary>
+    /// The total size of the model in bytes.
+    /// </summary>
     [ObservableProperty] private long _totalBytes;
+
+    /// <summary>
+    /// The current download speed in megabytes per second.
+    /// </summary>
     [ObservableProperty] private double _downloadSpeed;
+
+    /// <summary>
+    /// The current status of the download operation, including state and error messages.
+    /// </summary>
     [ObservableProperty] private ModelDownloadStatus? _status;
 }

--- a/avallama/Models/Download/ModelDownloadStatus.cs
+++ b/avallama/Models/Download/ModelDownloadStatus.cs
@@ -5,17 +5,35 @@ using avallama.Constants.States;
 
 namespace avallama.Models.Download;
 
+/// <summary>
+/// Represents the current status and accompanying message of a model download operation.
+/// </summary>
 public class ModelDownloadStatus
 {
-    // empty constructor for AXAML
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ModelDownloadStatus"/> class.
+    /// Required empty constructor for AXAML instantiation.
+    /// </summary>
     public ModelDownloadStatus() { }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ModelDownloadStatus"/> class with a specific state and an optional message.
+    /// </summary>
+    /// <param name="state">The current state of the download.</param>
+    /// <param name="message">An optional localized message detailing the state (typically used for errors).</param>
     public ModelDownloadStatus(DownloadState state, string? message = null)
     {
         DownloadState = state;
         Message = message;
     }
 
+    /// <summary>
+    /// Gets or sets the current state of the download.
+    /// </summary>
     public DownloadState DownloadState { get; set; } = DownloadState.Downloadable;
+
+    /// <summary>
+    /// Gets or sets the descriptive message associated with the current state.
+    /// </summary>
     public string? Message { get; set; }
 }

--- a/avallama/Models/QueueItem.cs
+++ b/avallama/Models/QueueItem.cs
@@ -7,12 +7,27 @@ using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace avallama.Models;
 
+/// <summary>
+/// Represents an abstract base class for items that can be enqueued and processed by the <see cref="avallama.Services.Queue.QueueService{T}"/>.
+/// </summary>
 public abstract class QueueItem : ObservableObject
 {
     private CancellationTokenSource _cts = new();
+
+    /// <summary>
+    /// Gets the cancellation token associated with this specific queue item.
+    /// </summary>
     public CancellationToken Token => _cts.Token;
+
+    /// <summary>
+    /// Gets or sets the reason why this item was canceled.
+    /// Defaults to <see cref="QueueItemCancellationReason.Unknown"/>.
+    /// </summary>
     public QueueItemCancellationReason QueueItemCancellationReason { get; set; } = QueueItemCancellationReason.Unknown;
 
+    /// <summary>
+    /// Cancels the execution of this specific queue item if cancellation has not already been requested.
+    /// </summary>
     public void Cancel()
     {
         if (!_cts.IsCancellationRequested)
@@ -21,6 +36,10 @@ public abstract class QueueItem : ObservableObject
         }
     }
 
+    /// <summary>
+    /// Disposes the current cancellation token source and creates a new one,
+    /// effectively resetting the cancellation state of the item so it can be retried or re-queued.
+    /// </summary>
     public void ResetToken()
     {
         _cts.Dispose();

--- a/avallama/Services/Queue/ModelDownloadQueueService.cs
+++ b/avallama/Services/Queue/ModelDownloadQueueService.cs
@@ -14,31 +14,40 @@ using avallama.Utilities.Network;
 
 namespace avallama.Services.Queue;
 
+/// <summary>
+/// Defines a contract for a queue service specialized in handling model download requests.
+/// </summary>
 public interface IModelDownloadQueueService : IQueueService<ModelDownloadRequest>;
 
-public class ModelDownloadQueueService : QueueService<ModelDownloadRequest>, IModelDownloadQueueService
+/// <summary>
+/// A specialized queue service responsible for processing Ollama model download requests sequentially or in parallel.
+/// </summary>
+public class ModelDownloadQueueService(
+    IOllamaService ollamaService,
+    INetworkManager networkManager)
+    : QueueService<ModelDownloadRequest>, IModelDownloadQueueService
 {
-    private readonly IOllamaService _ollamaService;
-    private readonly INetworkManager _networkManager;
-
-    public ModelDownloadQueueService(
-        IOllamaService ollamaService,
-        INetworkManager networkManager)
-    {
-        _ollamaService = ollamaService;
-        _networkManager = networkManager;
-    }
-
+    /// <summary>
+    /// Processes a single model download request by communicating with the Ollama service.
+    /// Handles chunked downloads, speed calculation, and disk space verification.
+    /// </summary>
+    /// <param name="request">The download request containing model details.</param>
+    /// <param name="ct">The cancellation token to abort the download operation.</param>
+    /// <returns>A task representing the asynchronous download process.</returns>
+    /// <exception cref="NoInternetConnectionException">Thrown when there is no active internet connection.</exception>
+    /// <exception cref="InsufficientDiskSpaceException">Thrown when there is not enough available disk space to complete the download.</exception>
     protected override async Task ProcessItemAsync(ModelDownloadRequest request, CancellationToken ct)
     {
-        if (!await _networkManager.IsInternetAvailableAsync())
+        if (!await networkManager.IsInternetAvailableAsync())
         {
             throw new NoInternetConnectionException();
         }
 
         request.DownloadPartCount = 1;
-        await foreach (var chunk in _ollamaService.DownloadModelAsync(request.ModelName, ct))
+
+        await foreach (var chunk in ollamaService.DownloadModelAsync(request.ModelName, ct))
         {
+            // fail early if disk space runs out during download
             if (!DiskManager.IsEnoughDiskSpaceAvailable(request.TotalBytes))
             {
                 throw new InsufficientDiskSpaceException(request.TotalBytes,
@@ -47,12 +56,14 @@ public class ModelDownloadQueueService : QueueService<ModelDownloadRequest>, IMo
 
             if (chunk is { Total: not null, Completed: not null })
             {
+                // check if server started to stream a new part of the download
                 if (request.TotalBytes != 0 && chunk.Total.Value != request.TotalBytes)
                 {
                     request.DownloadPartCount++;
                 }
 
                 var speed = request.SpeedCalculator.CalculateSpeed(chunk.Completed.Value);
+
                 if (request.Status == null || request.Status.DownloadState == DownloadState.Queued)
                 {
                     request.Status = new ModelDownloadStatus(DownloadState.Downloading);
@@ -63,6 +74,7 @@ public class ModelDownloadQueueService : QueueService<ModelDownloadRequest>, IMo
                 request.DownloadSpeed = speed;
             }
 
+            // if Ollama API indicates successful completion we set the status to Downloaded
             if (chunk.Status == "success")
             {
                 request.Status = new ModelDownloadStatus(DownloadState.Downloaded);
@@ -70,11 +82,17 @@ public class ModelDownloadQueueService : QueueService<ModelDownloadRequest>, IMo
         }
     }
 
+    /// <summary>
+    /// Handles exceptions thrown during the download process, and sets a localized error message on the request status.
+    /// </summary>
+    /// <param name="request">The request that failed.</param>
+    /// <param name="ex">The exception that caused the failure.</param>
     protected override void OnItemFailed(ModelDownloadRequest request, Exception ex)
     {
         string errorKey;
         string? arg = null;
 
+        // map exception types to localization keys
         switch (ex)
         {
             case NoInternetConnectionException:
@@ -115,6 +133,7 @@ public class ModelDownloadQueueService : QueueService<ModelDownloadRequest>, IMo
 
         var localizedMessage = LocalizationService.GetString(errorKey);
 
+        // safely format the localized string if an argument is provided
         if (!string.IsNullOrEmpty(arg))
         {
             try
@@ -130,25 +149,35 @@ public class ModelDownloadQueueService : QueueService<ModelDownloadRequest>, IMo
         request.Status = new ModelDownloadStatus(DownloadState.Failed, localizedMessage);
     }
 
+    /// <summary>
+    /// Handles the cancellation logic for a download request, updating its state
+    /// based on the explicit reason for cancellation.
+    /// </summary>
+    /// <param name="request">The request that was canceled.</param>
     protected override void OnItemCancelled(ModelDownloadRequest request)
     {
+        // reset speed metrics
         request.DownloadSpeed = 0.0;
         request.SpeedCalculator.Reset();
 
         switch (request.QueueItemCancellationReason)
         {
             case QueueItemCancellationReason.UserCancelRequest:
+                // full abort, reset all progress
                 request.Status = new ModelDownloadStatus(DownloadState.Downloadable);
                 request.DownloadedBytes = 0;
                 request.TotalBytes = 0;
                 request.DownloadPartCount = 0;
                 break;
+
             case QueueItemCancellationReason.SystemScaling:
+                // service is scaling down parallelism, requeue the item for later processing
                 request.Status = new ModelDownloadStatus(DownloadState.Queued);
                 request.QueueItemCancellationReason = QueueItemCancellationReason.Unknown;
                 request.ResetToken();
                 Enqueue(request);
                 break;
+
             case QueueItemCancellationReason.UserPauseRequest:
             default:
                 request.Status = new ModelDownloadStatus(DownloadState.Paused);

--- a/avallama/Services/Queue/ModelDownloadQueueService.cs
+++ b/avallama/Services/Queue/ModelDownloadQueueService.cs
@@ -47,7 +47,6 @@ public class ModelDownloadQueueService(
 
         await foreach (var chunk in ollamaService.DownloadModelAsync(request.ModelName, ct))
         {
-            // fail early if disk space runs out during download
             if (!DiskManager.IsEnoughDiskSpaceAvailable(request.TotalBytes))
             {
                 throw new InsufficientDiskSpaceException(request.TotalBytes,
@@ -74,7 +73,6 @@ public class ModelDownloadQueueService(
                 request.DownloadSpeed = speed;
             }
 
-            // if Ollama API indicates successful completion we set the status to Downloaded
             if (chunk.Status == "success")
             {
                 request.Status = new ModelDownloadStatus(DownloadState.Downloaded);
@@ -92,7 +90,6 @@ public class ModelDownloadQueueService(
         string errorKey;
         string? arg = null;
 
-        // map exception types to localization keys
         switch (ex)
         {
             case NoInternetConnectionException:
@@ -156,7 +153,6 @@ public class ModelDownloadQueueService(
     /// <param name="request">The request that was canceled.</param>
     protected override void OnItemCancelled(ModelDownloadRequest request)
     {
-        // reset speed metrics
         request.DownloadSpeed = 0.0;
         request.SpeedCalculator.Reset();
 

--- a/avallama/Services/Queue/QueueService.cs
+++ b/avallama/Services/Queue/QueueService.cs
@@ -125,7 +125,6 @@ public abstract class QueueService<T> : IQueueService<T>
     /// <returns>A task representing the asynchronous queue processing loop.</returns>
     private async Task ProcessQueueAsync()
     {
-        // ensures that only one instance of the processing loop is running at a time
         if (!await _semaphore.WaitAsync(0)) return;
 
         try
@@ -174,7 +173,6 @@ public abstract class QueueService<T> : IQueueService<T>
                     continue;
                 }
 
-                // try to take an item from the queue, if empty we break from the loop
                 if (!_queue.TryDequeue(out var item))
                 {
                     break;
@@ -183,7 +181,7 @@ public abstract class QueueService<T> : IQueueService<T>
                 var internalCts = CancellationTokenSource.CreateLinkedTokenSource(_serviceCts.Token, item.Token);
 
                 // do not pass the cancellation token since we continue with a cleaning code which has to run always
-                // this is necessary in case the cleaning is not executed if we breaked the loop already
+                // this is necessary in case the cleaning is not executed if we have broken the loop
                 var processingTask = TryProcessItemAsync(item, internalCts).ContinueWith(_ =>
                 {
                     lock (_lock)
@@ -281,9 +279,6 @@ public abstract class QueueService<T> : IQueueService<T>
         _queue.Clear();
     }
 
-    /// <summary>
-    /// Releases all resources used by the <see cref="QueueService{T}"/>.
-    /// </summary>
     public void Dispose()
     {
         lock (_lock)

--- a/avallama/Services/Queue/QueueService.cs
+++ b/avallama/Services/Queue/QueueService.cs
@@ -9,35 +9,77 @@ using System.Threading;
 using System.Threading.Tasks;
 using avallama.Constants;
 using avallama.Models;
+using avallama.Models.Download;
 
 namespace avallama.Services.Queue;
 
+/// <summary>
+/// Defines a contract for a service that manages a queue of items to be processed concurrently.
+/// </summary>
+/// <typeparam name="T">The type of items in the queue, which must inherit from <see cref="QueueItem"/>.</typeparam>
 public interface IQueueService<T> : IDisposable where T : QueueItem
 {
+    /// <summary>
+    /// Adds an item to the end of the queue and triggers processing.
+    /// </summary>
+    /// <param name="item">The item to enqueue.</param>
     void Enqueue(T item);
+
+    /// <summary>
+    /// Retrieves a snapshot of the items currently waiting in the queue.
+    /// </summary>
+    /// <returns>A read-only list of queued items.</returns>
     IReadOnlyList<T> GetQueuedItems();
+
+    /// <summary>
+    /// Adjusts the maximum number of items that can be processed simultaneously.
+    /// </summary>
+    /// <param name="newCount">The new maximum concurrency level. Must be at least 1.</param>
     void SetParallelism(int newCount);
+
+    /// <summary>
+    /// Cancels all currently processing items and clears the queue.
+    /// </summary>
     void CancelAll();
 }
 
-internal class RunningTaskContext<T>
-{
-    public required T Item { get; init; }
-    public required Task Task { get; init; }
-    public required CancellationTokenSource Cts { get; init; }
-}
-
+/// <summary>
+/// Provides a base implementation for an asynchronous, parallel queue processing service.
+/// </summary>
+/// <typeparam name="T">The type of items in the queue, which must inherit from <see cref="QueueItem"/>.</typeparam>
 public abstract class QueueService<T> : IQueueService<T>
     where T : QueueItem
 {
+    /// <summary>
+    /// Represents the context of a currently executing task within the queue service.
+    /// </summary>
+    private class RunningTaskContext
+    {
+        /// <summary>
+        /// Gets the queue item being processed.
+        /// </summary>
+        public required T Item { get; init; }
+
+        /// <summary>
+        /// Gets the task representing the asynchronous processing operation.
+        /// </summary>
+        public required Task Task { get; init; }
+
+        /// <summary>
+        /// Gets the linked cancellation token source for this specific execution context.
+        /// </summary>
+        public required CancellationTokenSource Cts { get; init; }
+    }
+
     private readonly ConcurrentQueue<T> _queue = new();
     private readonly SemaphoreSlim _semaphore = new(1, 1);
-    private readonly List<RunningTaskContext<T>> _runningTaskContexts = [];
+    private readonly List<RunningTaskContext> _runningTaskContexts = [];
     private CancellationTokenSource _serviceCts = new();
     private TaskCompletionSource _parallelismChangeTcs = new();
     private int _maxParallelism = 1;
     private readonly Lock _lock = new();
 
+    /// <inheritdoc />
     public void SetParallelism(int newCount)
     {
         if (newCount < 1) return;
@@ -51,6 +93,7 @@ public abstract class QueueService<T> : IQueueService<T>
                 if (excessCount <= 0) return;
                 var tasksToCancel = _runningTaskContexts.TakeLast(excessCount).ToList();
 
+                // cancel excess tasks
                 foreach (var context in tasksToCancel.Where(context => !context.Cts.IsCancellationRequested))
                 {
                     context.Item.QueueItemCancellationReason = QueueItemCancellationReason.SystemScaling;
@@ -65,22 +108,29 @@ public abstract class QueueService<T> : IQueueService<T>
         _ = ProcessQueueAsync();
     }
 
+    /// <inheritdoc />
     public void Enqueue(T item)
     {
         _queue.Enqueue(item);
         _ = ProcessQueueAsync();
     }
 
+    /// <inheritdoc />
     public IReadOnlyList<T> GetQueuedItems() => _queue.ToList();
 
+    /// <summary>
+    /// The core loop that continuously monitors the queue and dispatches items to be processed
+    /// while respecting the configured concurrency limits.
+    /// </summary>
+    /// <returns>A task representing the asynchronous queue processing loop.</returns>
     private async Task ProcessQueueAsync()
     {
-        // ensures that one while loop runs only
+        // ensures that only one instance of the processing loop is running at a time
         if (!await _semaphore.WaitAsync(0)) return;
 
         try
         {
-            while (!_serviceCts.Token.IsCancellationRequested)
+            while (IsServiceActive())
             {
                 lock (_lock)
                 {
@@ -101,40 +151,30 @@ public abstract class QueueService<T> : IQueueService<T>
                 int currentCount;
                 int limit;
                 Task parallelismChangeTask;
+                Task[] tasksToWait;
 
                 lock (_lock)
                 {
-                    // count of the tasks in the queue at the moment
                     currentCount = _runningTaskContexts.Count;
-
-                    // limit of the tasks in the queue at the moment
                     limit = _maxParallelism;
-
                     parallelismChangeTask = _parallelismChangeTcs.Task;
+                    tasksToWait = _runningTaskContexts.Select(c => c.Task).ToArray();
                 }
 
-                if (currentCount >= limit)
+                if (currentCount >= limit && currentCount > 0)
                 {
-                    if (currentCount > 0)
+                    // if we reached the limit and there are running tasks, wait for them or wait for parallelism to change
+                    if (tasksToWait.Length > 0)
                     {
-                        Task[] tasksToWait;
-                        lock (_lock)
-                        {
-                            tasksToWait = _runningTaskContexts.Select(c => c.Task).ToArray();
-                        }
-
-                        if (tasksToWait.Length > 0)
-                        {
-                            // include the task which completes when parallelism settings have been changed
-                            // so when it completes we'll continue the loop and operate with the new limit
-                            var allTasksToWait = tasksToWait.Append(parallelismChangeTask);
-                            await Task.WhenAny(allTasksToWait);
-                        }
-                        continue;
+                        // include the task which completes when parallelism settings have been changed
+                        // so when it completes we'll continue the loop and operate with the new limit
+                        var allTasksToWait = tasksToWait.Append(parallelismChangeTask);
+                        await Task.WhenAny(allTasksToWait);
                     }
+                    continue;
                 }
 
-                // take an item from the queue, otherwise we break from the loop if the queue is empty
+                // try to take an item from the queue, if empty we break from the loop
                 if (!_queue.TryDequeue(out var item))
                 {
                     break;
@@ -142,12 +182,23 @@ public abstract class QueueService<T> : IQueueService<T>
 
                 var internalCts = CancellationTokenSource.CreateLinkedTokenSource(_serviceCts.Token, item.Token);
 
-                var processingTask = TryProcessItemAsync(item, internalCts);
+                // do not pass the cancellation token since we continue with a cleaning code which has to run always
+                // this is necessary in case the cleaning is not executed if we breaked the loop already
+                var processingTask = TryProcessItemAsync(item, internalCts).ContinueWith(_ =>
+                {
+                    lock (_lock)
+                    {
+                        var ctx = _runningTaskContexts.FirstOrDefault(c => c.Item == item);
+                        if (ctx == null) return;
+                        ctx.Cts.Dispose();
+                        _runningTaskContexts.Remove(ctx);
+                    }
+                });
 
                 lock (_lock)
                 {
-                    // create a new queue task associated with the data, task and cancellationtoken so we can keep track of it
-                    _runningTaskContexts.Add(new RunningTaskContext<T>
+                    // creates a new queue task associated with the data, task and cancellation token so we can keep track of it
+                    _runningTaskContexts.Add(new RunningTaskContext
                     {
                         Item = item,
                         Task = processingTask,
@@ -162,6 +213,25 @@ public abstract class QueueService<T> : IQueueService<T>
         }
     }
 
+    /// <summary>
+    /// Safely determines whether the overall queue service is still active and has not been canceled.
+    /// Utilizes a lock to ensure the cancellation token state is read in a thread-safe manner.
+    /// </summary>
+    /// <returns><c>True</c> if the service is active and running; otherwise, <c>False</c>.</returns>
+    private bool IsServiceActive()
+    {
+        lock (_lock)
+        {
+            return !_serviceCts.IsCancellationRequested;
+        }
+    }
+
+    /// <summary>
+    /// Safely attempts to process a queue item, handling standard cancellation and execution exceptions.
+    /// </summary>
+    /// <param name="item">The item to process.</param>
+    /// <param name="linkedCts">The linked cancellation token source to monitor for cancellation.</param>
+    /// <returns>A task representing the processing operation.</returns>
     private async Task TryProcessItemAsync(T item, CancellationTokenSource linkedCts)
     {
         try
@@ -178,20 +248,51 @@ public abstract class QueueService<T> : IQueueService<T>
         }
     }
 
+    /// <summary>
+    /// When overridden in a derived class, contains the actual processing logic for a single queue item.
+    /// </summary>
+    /// <param name="item">The item to process.</param>
+    /// <param name="ct">The cancellation token to observe for cancellation requests.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
     protected abstract Task ProcessItemAsync(T item, CancellationToken ct);
+
+    /// <summary>
+    /// Invoked when an item's processing is canceled via an <see cref="OperationCanceledException"/>.
+    /// </summary>
+    /// <param name="item">The item that was canceled.</param>
     protected virtual void OnItemCancelled(T item) {}
+
+    /// <summary>
+    /// Invoked when an item's processing throws an unhandled exception.
+    /// </summary>
+    /// <param name="item">The item that failed.</param>
+    /// <param name="ex">The exception that occurred during processing.</param>
     protected virtual void OnItemFailed(T item, Exception ex) {}
 
+    /// <inheritdoc />
     public void CancelAll()
     {
-        _serviceCts.Cancel();
-        _serviceCts.Dispose();
-        _serviceCts = new CancellationTokenSource();
+        lock (_lock)
+        {
+            _serviceCts.Cancel();
+            _serviceCts.Dispose();
+            _serviceCts = new CancellationTokenSource();
+        }
         _queue.Clear();
     }
 
+    /// <summary>
+    /// Releases all resources used by the <see cref="QueueService{T}"/>.
+    /// </summary>
     public void Dispose()
     {
+        lock (_lock)
+        {
+            _serviceCts.Cancel();
+            _serviceCts.Dispose();
+            _queue.Clear();
+        }
+
         _semaphore.Dispose();
         GC.SuppressFinalize(this);
     }

--- a/avallama/Services/UpdateService.cs
+++ b/avallama/Services/UpdateService.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) Márk Csörgő and Martin Bartos
 // Licensed under the MIT License. See LICENSE file for details.
 
+using System;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text.Json;
 using System.Threading.Tasks;
-
 using avallama.Utilities.Network;
 
 namespace avallama.Services;
@@ -25,7 +25,7 @@ public interface IUpdateService
 
 public class UpdateService : IUpdateService
 {
-    private readonly string _version;
+    private readonly Version _version;
     private readonly HttpClient _httpClient;
     private readonly INetworkManager _networkManager;
 
@@ -34,7 +34,7 @@ public class UpdateService : IUpdateService
         _version = App.Version;
         _httpClient = httpClient;
         _httpClient.DefaultRequestHeaders.UserAgent.Add(
-            new ProductInfoHeaderValue("avallama", _version));
+            new ProductInfoHeaderValue("avallama", _version.ToString(3)));
         _httpClient.DefaultRequestHeaders.Accept.Add(
             new MediaTypeWithQualityHeaderValue("application/vnd.github+json"));
         _networkManager = networkManager;
@@ -54,7 +54,11 @@ public class UpdateService : IUpdateService
 
         var json = await response.Content.ReadAsStringAsync();
         using var doc = JsonDocument.Parse(json);
-        var latestVersion = doc.RootElement.GetProperty("tag_name").GetString();
-        return latestVersion != _version;
+        var remoteVersion = doc.RootElement.GetProperty("tag_name").GetString()?.TrimStart('v', 'V');
+
+        if (!Version.TryParse(remoteVersion, out var remoteParsedVersion)) return false;
+
+        return remoteParsedVersion > _version;
+
     }
 }

--- a/avallama/Services/UpdateService.cs
+++ b/avallama/Services/UpdateService.cs
@@ -34,7 +34,7 @@ public class UpdateService : IUpdateService
         _version = App.Version;
         _httpClient = httpClient;
         _httpClient.DefaultRequestHeaders.UserAgent.Add(
-            new ProductInfoHeaderValue("avallama", _version.ToString(3)));
+            new ProductInfoHeaderValue("avallama", $"v{_version.ToString(3)}"));
         _httpClient.DefaultRequestHeaders.Accept.Add(
             new MediaTypeWithQualityHeaderValue("application/vnd.github+json"));
         _networkManager = networkManager;

--- a/avallama/Utilities/ColorProvider.cs
+++ b/avallama/Utilities/ColorProvider.cs
@@ -7,7 +7,7 @@ using Avalonia.Media;
 using Avalonia.Media.Immutable;
 using Avalonia.Styling;
 
-namespace avallama.Utilities.Render;
+namespace avallama.Utilities;
 
 // returns the color for the given color key based on the current theme
 public static class ColorProvider

--- a/avallama/ViewModels/GreetingViewModel.cs
+++ b/avallama/ViewModels/GreetingViewModel.cs
@@ -7,6 +7,8 @@ namespace avallama.ViewModels;
 
 public partial class GreetingViewModel : PageViewModel
 {
+    public static string AppVersion => $"v{App.Version.ToString(3)}";
+
     public GreetingViewModel()
     {
         // setting the page type that this viewmodel handles

--- a/avallama/ViewModels/SettingsViewModel.cs
+++ b/avallama/ViewModels/SettingsViewModel.cs
@@ -152,7 +152,7 @@ public partial class SettingsViewModel : PageViewModel
         }
     }
 
-    public string AppVersion => App.Version;
+    public string AppVersion => $"v{App.Version.ToString(3)}";
 
     public SettingsViewModel(DialogService dialogService, ConfigurationService configurationService,
         IMessenger messenger, INetworkManager networkManager)

--- a/avallama/Views/GreetingView.axaml
+++ b/avallama/Views/GreetingView.axaml
@@ -35,7 +35,7 @@ Licensed under the MIT License. See LICENSE file for details.
             </StackPanel>
         </StackPanel>
 
-        <TextBlock Text="{x:Static avallama:App.Version}"
+        <TextBlock Text="{Binding AppVersion}"
                    HorizontalAlignment="Right"
                    VerticalAlignment="Bottom"
                    Margin="10"

--- a/avallama/Views/SettingsView.axaml
+++ b/avallama/Views/SettingsView.axaml
@@ -165,7 +165,7 @@ Licensed under the MIT License. See LICENSE file for details.
                             <TextBlock Text="{services:LocalizationService Key='SHORT_DESC'}" FontStyle="Italic" />
                             <TextBlock Margin="0,16,0,0">
                                 <Run Text="{services:LocalizationService Key='VERSION_LABEL'}" FontWeight="Bold" />
-                                <Run Text="{x:Static avallama:App.Version}" />
+                                <Run Text="{Binding AppVersion}" />
                             </TextBlock>
                             <TextBlock>
                                 <Run Text="{services:LocalizationService Key='DEVELOPERS'}" FontWeight="Bold" />

--- a/docs/KnownIssues.md
+++ b/docs/KnownIssues.md
@@ -3,15 +3,12 @@
 This is a list of issues we are aware of that will be fixed in a subsequent release. Please do not open new issues for the following known problems, as they are already being addressed.
 
 **All platforms**:
-- Conversation titles may fail to generate correctly across various models.
-- Conversations do not currently support any form of rich text rendering. This includes Markdown, LaTeX, and custom tags (e.g., `<think>`).
+- When using some models (e.g. thinking or other specialized models), generated conversation titles may be malformed or missing.
+- Markdown, LaTeX and custom tags (e.g. `<think>`) rendering is not yet supported.
 - Automatic application restart when changing language settings may not work as expected.
-- The chat logic is currently unstable when handling multiple sessions. You may notice shared UI states (e.g., text entered in one chat appearing in another) or background generations stopping unexpectedly when switching views.
-- Failed or interrupted generations (e.g., if the Ollama server stops) do not properly transition to a "Failed" state and may remain stuck on "Generating..." indefinitely.
-- Extremely small models (e.g., all-minilm:22m) may fail to produce output, remaining stuck in the generation phase.
+- When performing actions in rapid succession (e.g. changing views / conversations) during message generation, the UI may break or misbehave.
+- If a message generation fails, the message may incorrectly display "Generating..." indefinitely.
 - Models downloaded outside the app (e.g., using latest tags via CLI) may appear as duplicates or cause errors.
-- Image generation and cloud-based models are not yet supported.
-- In-app navigation is partially implemented; the back button may not always return to the correct previous page.
 
 **Windows**:
 - When receiving a very large response at a high token/sec, memory usage can climb higher than normal.
@@ -19,7 +16,3 @@ This is a list of issues we are aware of that will be fixed in a subsequent rele
 **Linux**:
 - When uninstalling, configuration files in `~/.config/avallama` are not removed automatically.
 - When starting the app from a terminal, killing the app prints a stack trace to the terminal.
-
-**Ubuntu**:
-- The `.deb` package is not functional on Ubuntu.
-- The application icon is rendered at a very low resolution in some desktop environments.

--- a/docs/KnownIssues.md
+++ b/docs/KnownIssues.md
@@ -3,10 +3,15 @@
 This is a list of issues we are aware of that will be fixed in a subsequent release. Please do not open new issues for the following known problems, as they are already being addressed.
 
 **All platforms**:
-- When using a thinking model, generated conversation titles may be malformed or missing.
-- Markdown and custom tags (e.g. `<think>`) rendering is not yet supported.
-- Automatic restarting of the app when changing language settings may not work as expected.
-- Some models in the model library (e.g. cloud models) are incorrectly available to download.
+- Conversation titles may fail to generate correctly across various models.
+- Conversations do not currently support any form of rich text rendering. This includes Markdown, LaTeX, and custom tags (e.g., `<think>`).
+- Automatic application restart when changing language settings may not work as expected.
+- The chat logic is currently unstable when handling multiple sessions. You may notice shared UI states (e.g., text entered in one chat appearing in another) or background generations stopping unexpectedly when switching views.
+- Failed or interrupted generations (e.g., if the Ollama server stops) do not properly transition to a "Failed" state and may remain stuck on "Generating..." indefinitely.
+- Extremely small models (e.g., all-minilm:22m) may fail to produce output, remaining stuck in the generation phase.
+- Models downloaded outside the app (e.g., using latest tags via CLI) may appear as duplicates or cause errors.
+- Image generation and cloud-based models are not yet supported.
+- In-app navigation is partially implemented; the back button may not always return to the correct previous page.
 
 **Windows**:
 - When receiving a very large response at a high token/sec, memory usage can climb higher than normal.
@@ -17,3 +22,4 @@ This is a list of issues we are aware of that will be fixed in a subsequent rele
 
 **Ubuntu**:
 - The `.deb` package is not functional on Ubuntu.
+- The application icon is rendered at a very low resolution in some desktop environments.


### PR DESCRIPTION
Closes https://github.com/4foureyes/avallamaplanning/issues/125

### Changes
- Fixed update detection bug. Replaced string comparison and the version type with `System.Version` to ensure update notifications are only triggered when the remote version is strictly newer than the local build.
- Fixed a bug where `RunningTaskContext` references remained in the memory after completion
- Refactored and optimized some of the code logic introduced in the v0.3.0 release
- Added comments and documentation for the following files and types:
  - `QueueItemCancellationReason.cs`
  - `DownloadState.cs`
  - `ModelDownloadRequest.cs`
  - `ModelDownloadStatus.cs`
  - `QueueItem.cs`
  - `QueueService.cs`
  - `ModelDownloadQueueService.cs` 
