### PR TITLE
Implement partial test coverage for features introduced in v0.3.0

### DIFF
--- a/avallama.Tests/Mocks/TestQueueService.cs
+++ b/avallama.Tests/Mocks/TestQueueService.cs
@@ -1,0 +1,65 @@
+// Copyright (c) Márk Csörgő and Martin Bartos
+// Licensed under the MIT License. See LICENSE file for details.
+
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+using avallama.Models;
+using avallama.Services.Queue;
+
+namespace avallama.Tests.Mocks;
+
+public class TestQueueItem : QueueItem
+{
+    public string Id { get; } = Guid.NewGuid().ToString();
+}
+
+public class TestQueueService : QueueService<TestQueueItem>
+{
+    public ConcurrentDictionary<string, TaskCompletionSource> ProcessingBlockers { get; } = new();
+
+    public ConcurrentBag<TestQueueItem> ProcessedItems { get; } = [];
+    public ConcurrentBag<TestQueueItem> CanceledItems { get; } = [];
+    public ConcurrentBag<(TestQueueItem Item, Exception Exception)> FailedItems { get; } = [];
+
+    public bool ThrowExceptionOnProcess { get; set; }
+
+    protected override async Task ProcessItemAsync(TestQueueItem item, CancellationToken ct)
+    {
+        var tcs = new TaskCompletionSource();
+        ProcessingBlockers[item.Id] = tcs;
+
+        if (ThrowExceptionOnProcess)
+        {
+            throw new InvalidOperationException("Simulated failure.");
+        }
+
+        await using (ct.Register(() => tcs.TrySetCanceled(ct)))
+        {
+            await tcs.Task;
+        }
+
+        ProcessedItems.Add(item);
+    }
+
+    protected override void OnItemCanceled(TestQueueItem item)
+    {
+        CanceledItems.Add(item);
+        base.OnItemCanceled(item);
+    }
+
+    protected override void OnItemFailed(TestQueueItem item, Exception ex)
+    {
+        FailedItems.Add((item, ex));
+        base.OnItemFailed(item, ex);
+    }
+
+    public void CompleteItem(TestQueueItem item)
+    {
+        if (ProcessingBlockers.TryGetValue(item.Id, out var tcs))
+        {
+            tcs.TrySetResult();
+        }
+    }
+}

--- a/avallama.Tests/Services/Ollama/OllamaApiClientTests.cs
+++ b/avallama.Tests/Services/Ollama/OllamaApiClientTests.cs
@@ -20,7 +20,7 @@ using Moq;
 using Moq.Protected;
 using Xunit;
 
-namespace avallama.Tests.Services;
+namespace avallama.Tests.Services.Ollama;
 
 public class OllamaApiClientTests : IClassFixture<TestServicesFixture>
 {

--- a/avallama.Tests/Services/Ollama/OllamaProcessManagerTests.cs
+++ b/avallama.Tests/Services/Ollama/OllamaProcessManagerTests.cs
@@ -8,7 +8,7 @@ using avallama.Tests.Fixtures;
 using avallama.Tests.Mocks;
 using Xunit;
 
-namespace avallama.Tests.Services;
+namespace avallama.Tests.Services.Ollama;
 
 public class OllamaProcessManagerTests : IClassFixture<TestServicesFixture>
 {

--- a/avallama.Tests/Services/Ollama/OllamaScraperTests.cs
+++ b/avallama.Tests/Services/Ollama/OllamaScraperTests.cs
@@ -17,7 +17,7 @@ using Moq;
 using Moq.Protected;
 using Xunit;
 
-namespace avallama.Tests.Services;
+namespace avallama.Tests.Services.Ollama;
 
 public class OllamaScraperTests
 {

--- a/avallama.Tests/Services/Ollama/OllamaServiceTests.cs
+++ b/avallama.Tests/Services/Ollama/OllamaServiceTests.cs
@@ -4,7 +4,7 @@
 using avallama.Tests.Fixtures;
 using Xunit;
 
-namespace avallama.Tests.Services;
+namespace avallama.Tests.Services.Ollama;
 
 public class OllamaServiceTests : IClassFixture<TestServicesFixture>
 {

--- a/avallama.Tests/Services/Persistence/ConfigurationServiceTests.cs
+++ b/avallama.Tests/Services/Persistence/ConfigurationServiceTests.cs
@@ -4,7 +4,7 @@
 using avallama.Services.Persistence;
 using Xunit;
 
-namespace avallama.Tests.Services;
+namespace avallama.Tests.Services.Persistence;
 
 public class ConfigurationServiceTests
 {

--- a/avallama.Tests/Services/Persistence/ConversationsServiceTests.cs
+++ b/avallama.Tests/Services/Persistence/ConversationsServiceTests.cs
@@ -13,7 +13,7 @@ using avallama.Services.Persistence;
 using Microsoft.Data.Sqlite;
 using Xunit;
 
-namespace avallama.Tests.Services;
+namespace avallama.Tests.Services.Persistence;
 
 [Collection("Database Tests")]
 public class ConversationServiceTests : IDisposable

--- a/avallama.Tests/Services/Persistence/DatabaseInitServiceTests.cs
+++ b/avallama.Tests/Services/Persistence/DatabaseInitServiceTests.cs
@@ -9,7 +9,7 @@ using avallama.Services.Persistence;
 using avallama.Tests.Extensions;
 using Xunit;
 
-namespace avallama.Tests.Services;
+namespace avallama.Tests.Services.Persistence;
 
 [Collection("Database Tests")]
 public class DatabaseInitServiceTests

--- a/avallama.Tests/Services/Persistence/ModelCacheServiceTests.cs
+++ b/avallama.Tests/Services/Persistence/ModelCacheServiceTests.cs
@@ -13,7 +13,7 @@ using avallama.Services.Persistence;
 using Microsoft.Data.Sqlite;
 using Xunit;
 
-namespace avallama.Tests.Services;
+namespace avallama.Tests.Services.Persistence;
 
 [Collection("Database Tests")]
 public class ModelCacheServiceTests : IAsyncDisposable

--- a/avallama.Tests/Services/Queue/QueueServiceTests.cs
+++ b/avallama.Tests/Services/Queue/QueueServiceTests.cs
@@ -1,0 +1,202 @@
+// Copyright (c) Márk Csörgő and Martin Bartos
+// Licensed under the MIT License. See LICENSE file for details.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using avallama.Constants;
+using avallama.Tests.Mocks;
+using Xunit;
+
+namespace avallama.Tests.Services.Queue;
+
+public class QueueServiceTests : IDisposable
+{
+    private readonly TestQueueService _service = new();
+
+    public void Dispose()
+    {
+        _service.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public void Enqueue_ShouldProcessItemSuccessfully()
+    {
+        var item = new TestQueueItem();
+
+        _service.Enqueue(item);
+        _service.CompleteItem(item);
+
+        Assert.Empty(_service.GetQueuedItems());
+        Assert.True(_service.ProcessingBlockers.ContainsKey(item.Id));
+    }
+
+    [Fact]
+    public void Enqueue_ShouldRespectMaxParallelism()
+    {
+        _service.SetParallelism(1);
+        var item1 = new TestQueueItem();
+        var item2 = new TestQueueItem();
+
+        _service.Enqueue(item1);
+        _service.Enqueue(item2);
+
+        var queued = _service.GetQueuedItems();
+        Assert.Single(queued);
+        Assert.Equal(item2, queued[0]);
+        Assert.False(_service.ProcessingBlockers.ContainsKey(item2.Id));
+    }
+
+    [Fact]
+    public void SetParallelism_Increase_ShouldStartWaitingItems()
+    {
+        _service.SetParallelism(1);
+        var item1 = new TestQueueItem();
+        var item2 = new TestQueueItem();
+
+        _service.Enqueue(item1);
+        _service.Enqueue(item2);
+
+        _service.SetParallelism(2);
+
+        Assert.Empty(_service.GetQueuedItems());
+
+        Assert.True(_service.ProcessingBlockers.ContainsKey(item1.Id));
+        Assert.True(_service.ProcessingBlockers.ContainsKey(item2.Id));
+    }
+
+    [Fact]
+    public void SetParallelism_Decrease_ShouldCancelExcessItemsWithSystemScalingReason()
+    {
+        _service.SetParallelism(2);
+        var item1 = new TestQueueItem();
+        var item2 = new TestQueueItem();
+
+        _service.Enqueue(item1);
+        _service.Enqueue(item2);
+
+        _service.SetParallelism(1);
+
+        var canceledItem = _service.CanceledItems.First();
+
+        Assert.Equal(item2, canceledItem);
+        Assert.Equal(QueueItemCancellationReason.SystemScaling, canceledItem.QueueItemCancellationReason);
+    }
+
+    [Fact]
+    public void QueueItem_Cancel_ShouldCancelOnlySpecificItem()
+    {
+        _service.SetParallelism(2);
+        var item1 = new TestQueueItem();
+        var item2 = new TestQueueItem();
+
+        _service.Enqueue(item1);
+        _service.Enqueue(item2);
+
+        item1.QueueItemCancellationReason = QueueItemCancellationReason.UserCancelRequest;
+        item1.Cancel();
+
+        Assert.Contains(item1, _service.CanceledItems);
+        Assert.DoesNotContain(item2, _service.CanceledItems);
+
+        _service.CompleteItem(item2);
+        Assert.Contains(item2, _service.ProcessedItems);
+    }
+
+    [Fact]
+    public void CancelAll_ShouldClearQueueAndCancelAllRunningItems()
+    {
+        _service.SetParallelism(1);
+        var item1 = new TestQueueItem();
+        var item2 = new TestQueueItem();
+
+        _service.Enqueue(item1);
+        _service.Enqueue(item2);
+
+        _service.CancelAll();
+
+        Assert.Empty(_service.GetQueuedItems());
+        Assert.Contains(item1, _service.CanceledItems);
+        Assert.Contains(item2, _service.CanceledItems);
+    }
+
+    [Fact]
+    public void ProcessItem_OnException_ShouldTriggerOnItemFailed()
+    {
+        _service.ThrowExceptionOnProcess = true;
+        var item = new TestQueueItem();
+
+        _service.Enqueue(item);
+
+        var failedItem = _service.FailedItems.First(f => f.Item == item);
+        Assert.IsType<InvalidOperationException>(failedItem.Exception);
+    }
+
+    [Fact]
+    public async Task CompleteItem_ShouldAutomaticallyStartNextQueuedItem()
+    {
+        _service.SetParallelism(1);
+        var item1 = new TestQueueItem();
+        var item2 = new TestQueueItem();
+
+        _service.Enqueue(item1);
+        _service.Enqueue(item2);
+
+        Assert.DoesNotContain(item1, _service.GetQueuedItems());
+        Assert.Contains(item2, _service.GetQueuedItems());
+
+        _service.CompleteItem(item1);
+
+        // TODO: remove after queue service is more testable
+        await Task.Delay(100);
+
+        Assert.DoesNotContain(item1, _service.GetQueuedItems());
+        Assert.DoesNotContain(item2, _service.GetQueuedItems());
+
+        Assert.Contains(item1, _service.ProcessedItems);
+
+        _service.CompleteItem(item2);
+
+        Assert.Contains(item2, _service.ProcessedItems);
+    }
+
+    [Fact]
+    public void SetParallelism_LessThanOne_ShouldBeIgnored()
+    {
+        _service.SetParallelism(2);
+        var item1 = new TestQueueItem();
+        var item2 = new TestQueueItem();
+        var item3 = new TestQueueItem();
+
+        _service.SetParallelism(0);
+        _service.SetParallelism(-5);
+
+        _service.Enqueue(item1);
+        _service.Enqueue(item2);
+        _service.Enqueue(item3);
+
+        var queued = _service.GetQueuedItems();
+        Assert.Single(queued);
+        Assert.Equal(item3, queued[0]);
+    }
+
+    [Fact]
+    public async Task ResetToken_ShouldAllowItemToBeRequeuedAfterCancellation()
+    {
+        var item = new TestQueueItem();
+        _service.Enqueue(item);
+
+        item.Cancel();
+        item.ResetToken();
+
+        _service.Enqueue(item);
+
+        // TODO: remove after queue service is more testable
+        await Task.Delay(100);
+
+        _service.CompleteItem(item);
+
+        Assert.Contains(item, _service.ProcessedItems);
+    }
+}

--- a/avallama.Tests/ViewModels/HomeViewModelTests.cs
+++ b/avallama.Tests/ViewModels/HomeViewModelTests.cs
@@ -182,6 +182,98 @@ public class HomeViewModelTests(TestServicesFixture fixture) : IClassFixture<Tes
             Times.Never);
     }
 
+    [Fact]
+    public async Task DeleteMessage_WhenValidMessage_DeletesFromDatabaseAndRemovesFromCollection()
+    {
+        fixture.DbMock.Reset();
+        var vm = CreateViewModel();
+
+        var conversation = new Conversation("A", "model-1:1b") { ConversationId = Guid.NewGuid() };
+        var message = new Message("Test message") { Id = 10 };
+        conversation.Messages.Add(message);
+
+        vm.SelectedConversation = conversation;
+
+        await vm.DeleteMessageCommand.ExecuteAsync(message);
+
+        fixture.DbMock.Verify(db => db.DeleteMessage(10), Times.Once);
+        Assert.DoesNotContain(message, conversation.Messages);
+    }
+
+    [Fact]
+    public async Task DeleteMessage_WhenFailedMessage_RemovesFromCollectionButDoesNotCallDatabase()
+    {
+        fixture.DbMock.Reset();
+        var vm = CreateViewModel();
+
+        var conversation = new Conversation("A", "model-1:1b") { ConversationId = Guid.NewGuid() };
+        var failedMessage = new FailedMessage { Id = -1 };
+        conversation.Messages.Add(failedMessage);
+
+        vm.SelectedConversation = conversation;
+
+        await vm.DeleteMessageCommand.ExecuteAsync(failedMessage);
+
+        fixture.DbMock.Verify(db => db.DeleteMessage(It.IsAny<long>()), Times.Never);
+
+        Assert.DoesNotContain(failedMessage, conversation.Messages);
+    }
+
+    [Fact]
+    public async Task SearchBoxText_WhenChanged_FiltersConversationsCorrectly()
+    {
+        fixture.DbMock.Reset();
+        fixture.OllamaMock.Reset();
+
+        var conv1 = new Conversation("C# Programming", string.Empty) { ConversationId = Guid.NewGuid() };
+        var conv2 = new Conversation("Python Scripts", string.Empty) { ConversationId = Guid.NewGuid() };
+        var conv3 = new Conversation("Avalonia UI Design", string.Empty) { ConversationId = Guid.NewGuid() };
+
+        fixture.DbMock.Setup(db => db.GetConversations()).ReturnsAsync([conv1, conv2, conv3]);
+
+        var vm = CreateViewModel();
+
+        fixture.OllamaMock.Raise(x =>
+            x.ApiStatusChanged += null, new OllamaApiStatus(OllamaConnectionState.Connected));
+
+        await vm.InitializeAsync();
+
+        Assert.Equal(3, vm.Conversations?.Count);
+
+        vm.SearchBoxText = "Python";
+
+        Assert.NotNull(vm.Conversations);
+        Assert.Single(vm.Conversations);
+        Assert.Contains(conv2, vm.Conversations);
+    }
+
+    [Fact]
+    public async Task SearchBoxText_WhenCleared_RestoresAllConversations()
+    {
+        fixture.DbMock.Reset();
+        fixture.OllamaMock.Reset();
+
+        var conv1 = new Conversation("C# Programming", string.Empty) { ConversationId = Guid.NewGuid() };
+        var conv2 = new Conversation("Python Scripts", string.Empty) { ConversationId = Guid.NewGuid() };
+
+        fixture.DbMock.Setup(db => db.GetConversations()).ReturnsAsync([conv1, conv2]);
+
+        var vm = CreateViewModel();
+
+        fixture.OllamaMock.Raise(x =>
+            x.ApiStatusChanged += null, new OllamaApiStatus(OllamaConnectionState.Connected));
+
+        await vm.InitializeAsync();
+
+        vm.SearchBoxText = "C#";
+        vm.SearchBoxText = string.Empty;
+
+        Assert.NotNull(vm.Conversations);
+        Assert.Equal(2, vm.Conversations.Count);
+        Assert.Contains(conv1, vm.Conversations);
+        Assert.Contains(conv2, vm.Conversations);
+    }
+
     private static async IAsyncEnumerable<OllamaResponse> MainStreamAsync()
     {
         yield return new OllamaResponse

--- a/avallama.Tests/ViewModels/ModelItemViewModelTests.cs
+++ b/avallama.Tests/ViewModels/ModelItemViewModelTests.cs
@@ -1,0 +1,122 @@
+// Copyright (c) Márk Csörgő and Martin Bartos
+// Licensed under the MIT License. See LICENSE file for details.
+
+using System.Threading.Tasks;
+using avallama.Constants;
+using avallama.Constants.States;
+using avallama.Models.Download;
+using avallama.Models.Ollama;
+using avallama.Tests.Fixtures;
+using avallama.ViewModels;
+using Moq;
+using Xunit;
+
+namespace avallama.Tests.ViewModels;
+
+public class ModelItemViewModelTests(TestServicesFixture fixture) : IClassFixture<TestServicesFixture>
+{
+    [Fact]
+    public void CurrentStatus_WhenNoRequestAndNotDownloaded_ReturnsDownloadable()
+    {
+        var model = new OllamaModel { Name = "llama2", IsDownloaded = false };
+        var vm = CreateViewModel(model);
+
+        var status = vm.CurrentStatus;
+
+        Assert.Equal(DownloadState.Downloadable, status.DownloadState);
+    }
+
+    [Fact]
+    public void PauseCommand_WhenDownloading_PausesRequestAndCancelsToken()
+    {
+        var model = new OllamaModel { Name = "llama2" };
+        var vm = CreateViewModel(model);
+        vm.DownloadCommand.Execute(null);
+
+        vm.DownloadRequest!.Status = new ModelDownloadStatus(DownloadState.Downloading);
+
+        vm.PauseCommand.Execute(null);
+
+        Assert.Equal(DownloadState.Paused, vm.DownloadRequest.Status?.DownloadState);
+        Assert.Equal(QueueItemCancellationReason.UserPauseRequest, vm.DownloadRequest.QueueItemCancellationReason);
+        Assert.True(vm.DownloadRequest.Token.IsCancellationRequested);
+    }
+
+    [Fact]
+    public void CancelCommand_WhenDownloading_CancelsRequestAndRemovesIt()
+    {
+        var model = new OllamaModel { Name = "llama2" };
+        var vm = CreateViewModel(model);
+        vm.DownloadCommand.Execute(null);
+        var oldRequest = vm.DownloadRequest;
+
+        vm.CancelCommand.Execute(null);
+
+        Assert.Null(vm.DownloadRequest);
+        Assert.True(oldRequest!.Token.IsCancellationRequested);
+        Assert.Equal(QueueItemCancellationReason.UserCancelRequest, oldRequest.QueueItemCancellationReason);
+    }
+
+    [Fact]
+    public async Task DownloadCompletedEvent_UpdatesDatabaseAndClearsRequest()
+    {
+        fixture.OllamaMock.Reset();
+        fixture.ModelCacheMock.Reset();
+        fixture.DialogMock.Reset();
+
+        var model = new OllamaModel { Name = "llama2", IsDownloaded = false };
+        var vm = CreateViewModel(model);
+
+        var tcs = new TaskCompletionSource();
+
+        fixture.ModelCacheMock
+            .Setup(m => m.ContainsModelAsync(model))
+            .ReturnsAsync(false);
+
+        fixture.ModelCacheMock
+            .Setup(m => m.InsertModelAsync(model))
+            .Returns(Task.CompletedTask)
+            .Callback(() => tcs.SetResult());
+
+        vm.DownloadCommand.Execute(null);
+
+        vm.DownloadRequest!.Status = new ModelDownloadStatus(DownloadState.Downloaded);
+
+        await tcs.Task;
+
+        Assert.True(vm.Model.IsDownloaded);
+        Assert.Null(vm.DownloadRequest);
+
+        fixture.OllamaMock.Verify(o => o.EnrichModelAsync(model), Times.Once);
+        fixture.ModelCacheMock.Verify(m => m.InsertModelAsync(model), Times.Once);
+        fixture.DialogMock.Verify(d => d.ShowErrorDialog(It.IsAny<string>(), It.IsAny<bool>()), Times.Never);
+    }
+
+    [Fact]
+    public void DownloadFailedEvent_ShowsErrorDialog()
+    {
+        fixture.DialogMock.Reset();
+        var model = new OllamaModel { Name = "llama3:1b" };
+        var vm = CreateViewModel(model);
+        vm.DownloadCommand.Execute(null);
+
+        vm.DownloadRequest!.Status = new ModelDownloadStatus(DownloadState.Failed, "No internet connection.");
+
+        fixture.DialogMock.Verify(d => d.ShowErrorDialog("No internet connection.", false), Times.Once);
+        Assert.NotNull(vm.DownloadRequest);
+    }
+
+    // TODO: implement missing test cases such (e.g. status text updates, model deletion etc.)
+
+    private ModelItemViewModel CreateViewModel(OllamaModel model)
+    {
+        return new ModelItemViewModel(
+            model,
+            fixture.OllamaMock.Object,
+            fixture.DownloadQueueMock.Object,
+            fixture.DialogMock.Object,
+            fixture.ModelCacheMock.Object,
+            fixture.MessengerMock.Object
+        );
+    }
+}

--- a/avallama/Services/Queue/ModelDownloadQueueService.cs
+++ b/avallama/Services/Queue/ModelDownloadQueueService.cs
@@ -151,7 +151,7 @@ public class ModelDownloadQueueService(
     /// based on the explicit reason for cancellation.
     /// </summary>
     /// <param name="request">The request that was canceled.</param>
-    protected override void OnItemCancelled(ModelDownloadRequest request)
+    protected override void OnItemCanceled(ModelDownloadRequest request)
     {
         request.DownloadSpeed = 0.0;
         request.SpeedCalculator.Reset();

--- a/avallama/Services/Queue/QueueService.cs
+++ b/avallama/Services/Queue/QueueService.cs
@@ -13,6 +13,8 @@ using avallama.Models.Download;
 
 namespace avallama.Services.Queue;
 
+// TODO: optimize queue processing for better stability and testing (possibly without fire and forget calls)
+
 /// <summary>
 /// Defines a contract for a service that manages a queue of items to be processed concurrently.
 /// </summary>
@@ -238,7 +240,7 @@ public abstract class QueueService<T> : IQueueService<T>
         }
         catch (OperationCanceledException)
         {
-            OnItemCancelled(item);
+            OnItemCanceled(item);
         }
         catch (Exception ex)
         {
@@ -258,7 +260,7 @@ public abstract class QueueService<T> : IQueueService<T>
     /// Invoked when an item's processing is canceled via an <see cref="OperationCanceledException"/>.
     /// </summary>
     /// <param name="item">The item that was canceled.</param>
-    protected virtual void OnItemCancelled(T item) {}
+    protected virtual void OnItemCanceled(T item) {}
 
     /// <summary>
     /// Invoked when an item's processing throws an unhandled exception.
@@ -276,6 +278,13 @@ public abstract class QueueService<T> : IQueueService<T>
             _serviceCts.Dispose();
             _serviceCts = new CancellationTokenSource();
         }
+
+        while (_queue.TryDequeue(out var item))
+        {
+            item.Cancel();
+            OnItemCanceled(item);
+        }
+
         _queue.Clear();
     }
 


### PR DESCRIPTION
### Changes
- Added unit tests for `QueueService`
- Added unit tests for `ModelItemViewModel`
- Added unit tests for `HomeViewModel` covering message deletion and conversation search

I couldn't complete full test coverage of all features introduced in v0.3.0 due to the required refactoring of `QueueService`, since it's not stable for testing.