### PR TITLE
Add average model/sec to Model Cache

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
           "VERSION=$version" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Restore & Publish
-        run: dotnet publish avallama/avallama.csproj -c Release -r win-x64 --self-contained true -o win-dist /p:PublishSingleFile=true
+        run: dotnet publish avallama/avallama.csproj -v n -c Release -r win-x64 --self-contained true -o win-dist /p:PublishSingleFile=true
 
       - name: Install Inno Setup
         run: |

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -14,6 +14,7 @@ env:
   DOTNET_CLI_TELEMETRY_OPTOUT: "1"
   DOTNET_NOLOGO: "true"
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: "1"
+  RELEASE_VERSION: ${{ github.event.inputs.version || '0.0.0' }}
 
 permissions:
   contents: read
@@ -73,10 +74,6 @@ jobs:
         with:
           dotnet-version: '10.x'
 
-      - name: Set version var
-        run: |
-          "VERSION=${{ github.event.inputs.version }}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-
       - name: Restore & Publish
         run: dotnet publish avallama/avallama.csproj -c Release -r win-x64 --self-contained true -o win-dist /p:PublishSingleFile=true
 
@@ -89,7 +86,7 @@ jobs:
       - name: Build Installer
         run: |
           & "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" `
-            /DAppVersion="${env:VERSION}" `
+            /DAppVersion="${{ env.RELEASE_VERSION }}" `
             scripts\installer.iss
 
   build-debian:
@@ -105,13 +102,10 @@ jobs:
         with:
           dotnet-version: '10.x'
 
-      - name: Set version var
-        run: echo "VERSION=${{ github.event.inputs.version }}" >> $GITHUB_ENV
-
       - name: Run Debian packaging script
         run: |
           chmod +x scripts/package-debian.sh
-          ./scripts/package-debian.sh "${{ env.VERSION }}"
+          ./scripts/package-debian.sh "${{ env.RELEASE_VERSION }}"
 
   build-arch:
     name: (Release Test) Build Arch Package
@@ -130,9 +124,6 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v6
 
-      - name: Set version var
-        run: echo "VERSION=${{ github.event.inputs.version }}" >> $GITHUB_ENV
-
       - name: Run Arch packaging script
         run: |
           useradd -m builder
@@ -140,7 +131,7 @@ jobs:
           cp -r avallama /tmp/build/
           cp -r scripts /tmp/build/
           chown -R builder:builder /tmp/build
-          sudo -u builder bash -c "cd /tmp/build && chmod +x scripts/package-arch.sh && scripts/package-arch.sh '${{ env.VERSION }}'"
+          sudo -u builder bash -c "cd /tmp/build && chmod +x scripts/package-arch.sh && scripts/package-arch.sh '${{ env.RELEASE_VERSION }}'"
 
 
   build-macos:
@@ -159,10 +150,7 @@ jobs:
       - name: Install create-dmg tool
         run: brew install create-dmg
 
-      - name: Set version var
-        run: echo "VERSION=${{ github.event.inputs.version }}" >> $GITHUB_ENV
-
       - name: Run macOS packaging script
         run: |
           chmod +x scripts/package-macos.sh
-          ./scripts/package-macos.sh "${{ env.VERSION }}"
+          ./scripts/package-macos.sh "${{ env.RELEASE_VERSION }}"

--- a/avallama.Tests/Services/Persistence/ConversationsServiceTests.cs
+++ b/avallama.Tests/Services/Persistence/ConversationsServiceTests.cs
@@ -65,6 +65,35 @@ public class ConversationServiceTests : IDisposable
 
                           CREATE INDEX IF NOT EXISTS idx_conversations_last_msg
                           ON conversations (last_message_sent_at);
+
+                          CREATE TABLE IF NOT EXISTS model_families (
+                          name TEXT PRIMARY KEY,
+                          description TEXT NOT NULL,
+                          pull_count INTEGER NOT NULL DEFAULT 0,
+                          labels TEXT,
+                          tag_count INTEGER NOT NULL DEFAULT 0,
+                          last_updated TEXT,
+                          cached_at TEXT NOT NULL,
+                          UNIQUE(name)
+                          );
+
+                          CREATE TABLE IF NOT EXISTS ollama_models (
+                          name TEXT PRIMARY KEY,
+                          family_name TEXT NOT NULL,
+                          parameters INTEGER,
+                          size INTEGER NOT NULL,
+                          format TEXT,
+                          quantization TEXT,
+                          architecture TEXT,
+                          block_count INTEGER,
+                          context_length INTEGER,
+                          embedding_length INTEGER,
+                          additional_info TEXT,
+                          is_downloaded INTEGER NOT NULL DEFAULT 0,
+                          avg_token_per_sec REAL,
+                          cached_at TEXT NOT NULL,
+                          FOREIGN KEY (family_name) REFERENCES model_families(name) ON DELETE CASCADE
+                          );
                           """;
         cmd.ExecuteNonQuery();
     }
@@ -287,6 +316,104 @@ public class ConversationServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task InsertMessage_WithGeneratedMessages_ShouldUpdateModelAverageTokenPerSec()
+    {
+        const string familyName = "llama-family";
+        const string modelName = "llama3.2:3b";
+        await SetupModelAsync(familyName, modelName);
+
+        var conversationId = await _conversationService.CreateConversation(
+            new Conversation(Guid.Empty, "Average Test", new List<Message>()));
+
+        await _conversationService.InsertMessage(
+            conversationId,
+            new GeneratedMessage("First", 10.0),
+            modelName,
+            10.0);
+
+        Assert.Equal(10.0, await GetModelAvgTokenPerSecAsync(modelName));
+
+        await _conversationService.InsertMessage(
+            conversationId,
+            new GeneratedMessage("Second", 20.0),
+            modelName,
+            20.0);
+
+        Assert.Equal(15.0, await GetModelAvgTokenPerSecAsync(modelName));
+    }
+
+    [Fact]
+    public async Task InsertMessage_WithDifferentModels_ShouldCalculateAveragesIndependently()
+    {
+        const string familyName = "llama-family";
+        const string firstModel = "llama3.2:3b";
+        const string secondModel = "mistral:7b";
+        await SetupModelAsync(familyName, firstModel);
+        await SetupModelAsync(familyName, secondModel);
+
+        var conversationId = await _conversationService.CreateConversation(
+            new Conversation(Guid.Empty, "Per Model Average", new List<Message>()));
+
+        await _conversationService.InsertMessage(
+            conversationId,
+            new GeneratedMessage("A1", 10.0),
+            firstModel,
+            10.0);
+        await _conversationService.InsertMessage(
+            conversationId,
+            new GeneratedMessage("B1", 40.0),
+            secondModel,
+            40.0);
+        await _conversationService.InsertMessage(
+            conversationId,
+            new GeneratedMessage("A2", 20.0),
+            firstModel,
+            20.0);
+
+        Assert.Equal(15.0, await GetModelAvgTokenPerSecAsync(firstModel));
+        Assert.Equal(40.0, await GetModelAvgTokenPerSecAsync(secondModel));
+    }
+
+    [Fact]
+    public async Task InsertMessage_WithUserMessage_ShouldNotUpdateModelAverageTokenPerSec()
+    {
+        const string familyName = "llama-family";
+        const string modelName = "llama3.2:3b";
+        await SetupModelAsync(familyName, modelName, avgTokenPerSec: 12.0);
+
+        var conversationId = await _conversationService.CreateConversation(
+            new Conversation(Guid.Empty, "User Message Average", new List<Message>()));
+
+        await _conversationService.InsertMessage(
+            conversationId,
+            new Message("User prompt"),
+            null,
+            null);
+
+        Assert.Equal(12.0, await GetModelAvgTokenPerSecAsync(modelName));
+    }
+
+    [Fact]
+    public async Task InsertMessage_WithFailedMessage_ShouldNotUpdateModelAverageTokenPerSec()
+    {
+        const string familyName = "llama-family";
+        const string modelName = "llama3.2:3b";
+        await SetupModelAsync(familyName, modelName, avgTokenPerSec: 25.0);
+
+        var conversationId = await _conversationService.CreateConversation(
+            new Conversation(Guid.Empty, "Failed Message Average", new List<Message>()));
+
+        var insertedId = await _conversationService.InsertMessage(
+            conversationId,
+            new FailedMessage(),
+            modelName,
+            42.0);
+
+        Assert.Equal(-1, insertedId);
+        Assert.Equal(25.0, await GetModelAvgTokenPerSecAsync(modelName));
+    }
+
+    [Fact]
     public async Task DeleteConversation_DeletesConversation()
     {
         var id = await _conversationService.CreateConversation(
@@ -306,6 +433,43 @@ public class ConversationServiceTests : IDisposable
         var messages = await _conversationService.GetMessagesForConversation(
             new Conversation(id, "Test", new List<Message>()));
         Assert.Empty(messages);
+    }
+
+    private async Task SetupModelAsync(string familyName, string modelName, double? avgTokenPerSec = null)
+    {
+        var now = DateTime.Now;
+
+        await using var familyCmd = _connection.CreateCommand();
+        familyCmd.CommandText =
+            "INSERT OR IGNORE INTO model_families (name, description, pull_count, tag_count, cached_at) VALUES (@Name, @Description, 0, 0, @CachedAt)";
+        familyCmd.Parameters.AddWithValue("@Name", familyName);
+        familyCmd.Parameters.AddWithValue("@Description", "Test model family");
+        familyCmd.Parameters.AddWithValue("@CachedAt", now);
+        await familyCmd.ExecuteNonQueryAsync();
+
+        await using var modelCmd = _connection.CreateCommand();
+        modelCmd.CommandText =
+            "INSERT INTO ollama_models (name, family_name, size, avg_token_per_sec, cached_at) VALUES (@Name, @FamilyName, 1, @AvgTokenPerSec, @CachedAt)";
+        modelCmd.Parameters.AddWithValue("@Name", modelName);
+        modelCmd.Parameters.AddWithValue("@FamilyName", familyName);
+        modelCmd.Parameters.AddWithValue("@AvgTokenPerSec", avgTokenPerSec ?? (object)DBNull.Value);
+        modelCmd.Parameters.AddWithValue("@CachedAt", now);
+        await modelCmd.ExecuteNonQueryAsync();
+    }
+
+    private async Task<double?> GetModelAvgTokenPerSecAsync(string modelName)
+    {
+        await using var cmd = _connection.CreateCommand();
+        cmd.CommandText = "SELECT avg_token_per_sec FROM ollama_models WHERE name = @ModelName";
+        cmd.Parameters.AddWithValue("@ModelName", modelName);
+        var result = await cmd.ExecuteScalarAsync();
+
+        if (result is null || result == DBNull.Value)
+        {
+            return null;
+        }
+
+        return Convert.ToDouble(result);
     }
 
     public void Dispose()

--- a/avallama.Tests/Services/Persistence/DatabaseInitServiceTests.cs
+++ b/avallama.Tests/Services/Persistence/DatabaseInitServiceTests.cs
@@ -3,10 +3,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 using System.Threading.Tasks;
-using avallama.Services;
 using avallama.Services.Persistence;
 using avallama.Tests.Extensions;
+using Microsoft.Data.Sqlite;
 using Xunit;
 
 namespace avallama.Tests.Services.Persistence;
@@ -168,5 +169,140 @@ public class DatabaseInitServiceTests
 
         var planText = string.Join(" ", queryPlan);
         Assert.Contains("idx_models_name_asc", planText, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task MigrateSchemaAsync_LegacyDownloadStatus_MigratesToIsDownloaded_AndAddsAvgTokenPerSec()
+    {
+        await using var conn = new SqliteConnection("Data Source=:memory:");
+        await conn.OpenAsync();
+
+        await using (var setupCmd = conn.CreateCommand())
+        {
+            setupCmd.CommandText = """
+                                   CREATE TABLE model_families (
+                                       name TEXT PRIMARY KEY,
+                                       description TEXT NOT NULL,
+                                       pull_count INTEGER NOT NULL DEFAULT 0,
+                                       labels TEXT,
+                                       tag_count INTEGER NOT NULL DEFAULT 0,
+                                       last_updated TEXT,
+                                       cached_at TEXT NOT NULL
+                                   );
+
+                                   CREATE TABLE ollama_models (
+                                       name TEXT PRIMARY KEY,
+                                       family_name TEXT NOT NULL,
+                                       parameters INTEGER,
+                                       size INTEGER NOT NULL,
+                                       format TEXT,
+                                       quantization TEXT,
+                                       architecture TEXT,
+                                       block_count INTEGER,
+                                       context_length INTEGER,
+                                       embedding_length INTEGER,
+                                       additional_info TEXT,
+                                       download_status INTEGER NOT NULL,
+                                       cached_at TEXT NOT NULL,
+                                       FOREIGN KEY (family_name) REFERENCES model_families(name) ON DELETE CASCADE
+                                   );
+
+                                   INSERT INTO model_families (name, description, pull_count, tag_count, cached_at)
+                                   VALUES ('family-1', 'Test Family', 1, 1, '2024-01-01T00:00:00Z');
+
+                                   INSERT INTO ollama_models (name, family_name, size, download_status, cached_at)
+                                   VALUES ('model-1', 'family-1', 100, 5, '2024-01-01T00:00:00Z');
+                                   """;
+            await setupCmd.ExecuteNonQueryAsync();
+        }
+
+        await InvokeMigrateSchemaAsync(conn);
+
+        Assert.False(await HasColumnAsync(conn, "ollama_models", "download_status"));
+        Assert.True(await HasColumnAsync(conn, "ollama_models", "is_downloaded"));
+        Assert.True(await HasColumnAsync(conn, "ollama_models", "avg_token_per_sec"));
+
+        await using var verifyCmd = conn.CreateCommand();
+        verifyCmd.CommandText = "SELECT is_downloaded FROM ollama_models WHERE name = 'model-1'";
+        var migratedFlag = (long)(await verifyCmd.ExecuteScalarAsync() ?? 0L);
+        Assert.Equal(1L, migratedFlag);
+    }
+
+    [Fact]
+    public async Task MigrateSchemaAsync_MissingAvgTokenPerSec_AddsColumnWithoutLegacyMigration()
+    {
+        await using var conn = new SqliteConnection("Data Source=:memory:");
+        await conn.OpenAsync();
+
+        await using (var setupCmd = conn.CreateCommand())
+        {
+            setupCmd.CommandText = """
+                                   CREATE TABLE model_families (
+                                       name TEXT PRIMARY KEY,
+                                       description TEXT NOT NULL,
+                                       pull_count INTEGER NOT NULL DEFAULT 0,
+                                       labels TEXT,
+                                       tag_count INTEGER NOT NULL DEFAULT 0,
+                                       last_updated TEXT,
+                                       cached_at TEXT NOT NULL
+                                   );
+
+                                   CREATE TABLE ollama_models (
+                                       name TEXT PRIMARY KEY,
+                                       family_name TEXT NOT NULL,
+                                       parameters INTEGER,
+                                       size INTEGER NOT NULL,
+                                       format TEXT,
+                                       quantization TEXT,
+                                       architecture TEXT,
+                                       block_count INTEGER,
+                                       context_length INTEGER,
+                                       embedding_length INTEGER,
+                                       additional_info TEXT,
+                                       is_downloaded INTEGER NOT NULL DEFAULT 0,
+                                       cached_at TEXT NOT NULL,
+                                       FOREIGN KEY (family_name) REFERENCES model_families(name) ON DELETE CASCADE
+                                   );
+
+                                   INSERT INTO model_families (name, description, pull_count, tag_count, cached_at)
+                                   VALUES ('family-2', 'Test Family 2', 1, 1, '2024-01-01T00:00:00Z');
+
+                                   INSERT INTO ollama_models (name, family_name, size, is_downloaded, cached_at)
+                                   VALUES ('model-2', 'family-2', 200, 0, '2024-01-01T00:00:00Z');
+                                   """;
+            await setupCmd.ExecuteNonQueryAsync();
+        }
+
+        await InvokeMigrateSchemaAsync(conn);
+
+        Assert.False(await HasColumnAsync(conn, "ollama_models", "download_status"));
+        Assert.True(await HasColumnAsync(conn, "ollama_models", "is_downloaded"));
+        Assert.True(await HasColumnAsync(conn, "ollama_models", "avg_token_per_sec"));
+
+        await using var verifyCmd = conn.CreateCommand();
+        verifyCmd.CommandText = "SELECT COUNT(*) FROM ollama_models WHERE name = 'model-2'";
+        var rowCount = (long)(await verifyCmd.ExecuteScalarAsync() ?? 0L);
+        Assert.Equal(1L, rowCount);
+    }
+
+    private static async Task InvokeMigrateSchemaAsync(SqliteConnection conn)
+    {
+        var method = typeof(DatabaseInitService).GetMethod(
+            "MigrateSchemaAsync",
+            BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(method);
+
+        var task = method.Invoke(null, [conn]) as Task;
+        Assert.NotNull(task);
+        await task;
+    }
+
+    private static async Task<bool> HasColumnAsync(SqliteConnection conn, string tableName, string columnName)
+    {
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"SELECT COUNT(*) FROM pragma_table_info('{tableName}') WHERE name = @name";
+        cmd.Parameters.AddWithValue("@name", columnName);
+        var count = (long)(await cmd.ExecuteScalarAsync() ?? 0L);
+        return count > 0;
     }
 }

--- a/avallama/Services/Persistence/ConversationService.cs
+++ b/avallama/Services/Persistence/ConversationService.cs
@@ -84,12 +84,12 @@ public class ConversationService : IConversationService, IDisposable
     public async Task<long> InsertMessage(Guid conversationId, Message message, string? modelName, double? tokenPerSec)
     {
         if (message is FailedMessage) return -1;
+        long newId = 0;
 
         using (DatabaseLock.Instance.AcquireWriteLock())
         {
             await using var transaction = await _connection.BeginTransactionAsync();
             var now = DateTime.Now;
-            long newId = 0;
 
             try
             {
@@ -131,8 +131,55 @@ public class ConversationService : IConversationService, IDisposable
                 // TODO: InterruptService
                 throw;
             }
-
+        }
+        // Update model's token/sec (this cannot be in the transaction, as it requires a query to calculate)
+        if (message is not GeneratedMessage || modelName is null)
+        {
             return newId;
+        }
+
+        var avgTokenPerSec = await CalculateModelAvgTokenPerSecAsync(modelName);
+        await UpdateModelAvgTokenPerSecAsync(avgTokenPerSec, modelName);
+        return newId;
+    }
+
+    private async Task<double> CalculateModelAvgTokenPerSecAsync(string modelName)
+    {
+        List<double> tokenPerSecValues = [];
+        using (DatabaseLock.Instance.AcquireReadLock())
+        {
+            await using var cmd = _connection.CreateCommand();
+            cmd.CommandText =
+                "SELECT tokens_per_sec FROM messages WHERE model_name IS NOT NULL AND model_name = @ModelName";
+            cmd.Parameters.AddWithValue("@ModelName", modelName);
+            await using var reader = await cmd.ExecuteReaderAsync();
+            if (!reader.HasRows) return 0;
+
+            try
+            {
+                while (await reader.ReadAsync())
+                {
+                    tokenPerSecValues.Add((double)reader["tokens_per_sec"]);
+                }
+            }
+            catch (Exception)
+            {
+                // TODO: InterruptService
+                throw;
+            }
+        }
+        return tokenPerSecValues.Average();
+    }
+
+    private async Task UpdateModelAvgTokenPerSecAsync(double avgTokenPerSec, string modelName)
+    {
+        using (DatabaseLock.Instance.AcquireWriteLock())
+        {
+            await using var cmd = _connection.CreateCommand();
+            cmd.CommandText = "UPDATE ollama_models SET avg_token_per_sec = @AverageTokenPerSec WHERE name = @ModelName";
+            cmd.Parameters.AddWithValue("@AverageTokenPerSec", avgTokenPerSec);
+            cmd.Parameters.AddWithValue("@ModelName", modelName);
+            await cmd.ExecuteNonQueryAsync();
         }
     }
 

--- a/avallama/Services/Persistence/DatabaseInitService.cs
+++ b/avallama/Services/Persistence/DatabaseInitService.cs
@@ -70,6 +70,7 @@ public class DatabaseInitService : IDatabaseInitService
                                            embedding_length INTEGER,
                                            additional_info TEXT,
                                            is_downloaded INTEGER NOT NULL DEFAULT 0,
+                                           avg_token_per_sec REAL,
                                            cached_at TEXT NOT NULL,
                                            FOREIGN KEY (family_name) REFERENCES model_families(name) ON DELETE CASCADE
                                            );
@@ -158,15 +159,20 @@ public class DatabaseInitService : IDatabaseInitService
         return storedHash != currentHash;
     }
 
+    /// <summary>
+    /// Method that migrates legacy database schemas to the current canonical schema.
+    /// There are currently 2 migrations that this method can complete:
+    /// Migration of the pre-v0.3.0 "download_status" column to "is_downloaded", and
+    /// migration of the pre-v0.3.2 "ollama_models" table to add a new "avg_tokens_per_sec" column.
+    /// </summary>
+    /// <param name="conn">The database connection</param>
+    /// <exception cref="InvalidOperationException">Thrown when schema migration fails.</exception>
     private static async Task MigrateSchemaAsync(SqliteConnection conn)
     {
         await using var transaction = await conn.BeginTransactionAsync();
         try
         {
-            await using var checkCmd = conn.CreateCommand();
-            checkCmd.CommandText =
-                "SELECT COUNT(*) FROM pragma_table_info('ollama_models') WHERE name='download_status'";
-            var hasDownloadStatusColumn = (long)(await checkCmd.ExecuteScalarAsync() ?? 0L) > 0;
+            var hasLegacyDownloadColumn = await HasColumnAsync(conn, "ollama_models", "download_status");
 
             await using var metaCmd = conn.CreateCommand();
             metaCmd.CommandText = """
@@ -177,10 +183,8 @@ public class DatabaseInitService : IDatabaseInitService
                                   """;
             await metaCmd.ExecuteNonQueryAsync();
 
-            // if the user has the previous "download_status" column then we migrate the db to the new "is_downloaded" column
-            // keep this migration script here indefinitely (possibly removeable in a 1.0.0 release)
-            // maybe extract this if we'll have more migration codes
-            if (hasDownloadStatusColumn)
+            // Migrate legacy pre-v0.3.0 table structure (download_status -> is_downloaded)
+            if (hasLegacyDownloadColumn)
             {
                 await using var migrationCmd = conn.CreateCommand();
                 migrationCmd.CommandText = """
@@ -199,6 +203,7 @@ public class DatabaseInitService : IDatabaseInitService
                                                    embedding_length INTEGER,
                                                    additional_info TEXT,
                                                    is_downloaded INTEGER NOT NULL DEFAULT 0, -- new column from v0.3.0
+                                                   avg_token_per_sec REAL, -- new column from v0.3.2
                                                    cached_at TEXT NOT NULL,
                                                    FOREIGN KEY (family_name) REFERENCES model_families(name) ON DELETE CASCADE
                                                );
@@ -230,7 +235,17 @@ public class DatabaseInitService : IDatabaseInitService
                                            """;
                 await migrationCmd.ExecuteNonQueryAsync();
             }
-            else
+
+            // Add new avg_token_per_sec column to databases pre-v0.3.2
+            var hasAvgTokenPerSecColumn = await HasColumnAsync(conn, "ollama_models", "avg_token_per_sec");
+            if (!hasAvgTokenPerSecColumn)
+            {
+                await using var addTpsColumnCmd = conn.CreateCommand();
+                addTpsColumnCmd.CommandText = "ALTER TABLE ollama_models ADD COLUMN avg_token_per_sec REAL";
+                await addTpsColumnCmd.ExecuteNonQueryAsync();
+            }
+
+            if (!hasLegacyDownloadColumn && hasAvgTokenPerSecColumn)
             {
                 await using var schemaCmd = conn.CreateCommand();
                 schemaCmd.CommandText = CanonicalSchema;
@@ -278,5 +293,14 @@ public class DatabaseInitService : IDatabaseInitService
                           """;
         var count = (long)(await cmd.ExecuteScalarAsync() ?? 0L);
         return count == 2;
+    }
+
+    private static async Task<bool> HasColumnAsync(SqliteConnection connection, string tableName, string columnName)
+    {
+        await using var cmd = connection.CreateCommand();
+        cmd.CommandText = $"SELECT COUNT(*) FROM pragma_table_info('{tableName}') WHERE name=@ColumnName";
+        cmd.Parameters.AddWithValue("@ColumnName", columnName);
+        var count = (long)(await cmd.ExecuteScalarAsync() ?? 0L);
+        return count > 0;
     }
 }

--- a/scripts/package-arch.sh
+++ b/scripts/package-arch.sh
@@ -19,7 +19,7 @@ mkdir -p src
 
 log "Running dotnet publish"
 dotnet publish "${PROJECT}" \
-  --verbosity quiet \
+  --verbosity normal \
   --nologo \
   --configuration Release \
   --self-contained true \

--- a/scripts/package-debian.sh
+++ b/scripts/package-debian.sh
@@ -16,7 +16,7 @@ PROJECT="avallama/avallama.csproj"
 
 log "Running dotnet publish"
 dotnet publish "${PROJECT}" \
-  --verbosity quiet \
+  --verbosity normal \
   --nologo \
   --configuration Release \
   --self-contained true \

--- a/scripts/package-macos.sh
+++ b/scripts/package-macos.sh
@@ -28,9 +28,9 @@ log "Compiling native macOS source code"
 clang -dynamiclib -framework Cocoa -arch x86_64 -arch arm64 -o "$DYLIB_OUTPUT" "$NATIVE_SRC"
 
 log "Running dotnet publish for osx-x64"
-dotnet publish "$PROJECT" -c Release -r osx-x64 --self-contained true -o mac-dist-x64 /p:PublishSingleFile=true
+dotnet publish "$PROJECT" -v n -c Release -r osx-x64 --self-contained true -o mac-dist-x64 /p:PublishSingleFile=true
 log "Running dotnet publish for osx-arm64"
-dotnet publish "$PROJECT" -c Release -r osx-arm64 --self-contained true -o mac-dist-arm64 /p:PublishSingleFile=true
+dotnet publish "$PROJECT" -v n -c Release -r osx-arm64 --self-contained true -o mac-dist-arm64 /p:PublishSingleFile=true
 
 create_app_structure() {
   local arch_dir="$1"


### PR DESCRIPTION
Closes https://github.com/4foureyes/avallamaplanning/issues/102

Changes:
- Added logic to `ConversationService` to calculate the average model token/sec after a message is generated and then save it alongside the model in the `ollama_models` table. I measured the overhead for this to be ~5-10 ms.
- Added the column migration logic, I suggest the next time we need to migrate, we create a separate ticket to extract the logic while remaining backwards compatible.
- Added tests for this
- Fixed the release test workflow to ensure that the release scripts have a version number to use so they don't exit early.
- Increased verbosity of the publish command in release workflows for better observability.