### PR TITLE
Bump avalonia version to 11.3.16

### DIFF
--- a/avallama.Tests/avallama.Tests.csproj
+++ b/avallama.Tests/avallama.Tests.csproj
@@ -12,7 +12,7 @@ Licensed under the MIT License. See LICENSE file for details.
 
     <!-- Versions -->
     <PropertyGroup>
-        <AvaloniaVersion>11.3.9</AvaloniaVersion>
+        <AvaloniaVersion>11.3.16</AvaloniaVersion>
         <DotNetLibVersion>10.0.0</DotNetLibVersion>
     </PropertyGroup>
 

--- a/avallama/avallama.csproj
+++ b/avallama/avallama.csproj
@@ -30,7 +30,7 @@ Licensed under the MIT License. See LICENSE file for details.
 
     <!-- Versions -->
     <PropertyGroup>
-        <AvaloniaVersion>11.3.9</AvaloniaVersion>
+        <AvaloniaVersion>11.3.16</AvaloniaVersion>
         <DotNetLibVersion>10.0.0</DotNetLibVersion>
     </PropertyGroup>
 


### PR DESCRIPTION
Bumping the version from 11.3.9 to 11.3.16 to pick up a patch for the vulnerability in `Tmds.DBus.Protocol`.

I strongly suggest cutting a new release with this newer version.