### PR TITLE
Dialog and ollama process retrieval fix + minor changes

### DIFF
--- a/avallama.Tests/avallama.Tests.csproj
+++ b/avallama.Tests/avallama.Tests.csproj
@@ -12,7 +12,7 @@ Licensed under the MIT License. See LICENSE file for details.
 
     <!-- Versions -->
     <PropertyGroup>
-        <AvaloniaVersion>11.3.9</AvaloniaVersion>
+        <AvaloniaVersion>11.3.16</AvaloniaVersion>
         <DotNetLibVersion>10.0.0</DotNetLibVersion>
     </PropertyGroup>
 

--- a/avallama/App.axaml.cs
+++ b/avallama/App.axaml.cs
@@ -27,7 +27,7 @@ public partial class App : Application
     private DialogService? _dialogService;
     private DatabaseInitService? _databaseInitService;
     public static SqliteConnection SharedDbConnection { get; private set; } = null!;
-    public static readonly Version Version = new (0, 3, 1);
+    public static readonly Version Version = new (0, 3, 2);
 
     public override void Initialize()
     {

--- a/avallama/Services/ApplicationService.cs
+++ b/avallama/Services/ApplicationService.cs
@@ -65,7 +65,7 @@ public class ApplicationService : IApplicationService
     public async Task AskOllamaStart()
     {
         // show ollama start confirmation dialog
-        var result = await _dialogService.ShowConfirmationDialog(
+        var result = await _dialogService.ShowConfirmationDialogAsync(
             title: LocalizationService.GetString("OLLAMA_RUN_FROM_DIALOG_TITLE"),
             positiveButtonText: LocalizationService.GetString("OLLAMA_RUN_FROM_DIALOG_LOCAL"),
             negativeButtonText: LocalizationService.GetString("OLLAMA_RUN_FROM_DIALOG_REMOTE"),
@@ -76,7 +76,7 @@ public class ApplicationService : IApplicationService
         if (result is ConfirmationResult { Confirmation: ConfirmationType.Negative })
         {
             // show input dialog with input fields specified
-            var dialogResult = await _dialogService.ShowInputDialog(
+            var dialogResult = await _dialogService.ShowInputDialogAsync(
                 title: LocalizationService.GetString("OLLAMA_REMOTE_DIALOG_TITLE"),
                 description: LocalizationService.GetString("OLLAMA_REMOTE_DIALOG_DESC"),
                 inputFields: new List<InputField>

--- a/avallama/Services/DialogService.cs
+++ b/avallama/Services/DialogService.cs
@@ -13,6 +13,7 @@ using avallama.Views.Dialogs;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Threading;
 using CommunityToolkit.Mvvm.Messaging;
 
 namespace avallama.Services;
@@ -82,7 +83,7 @@ public interface IDialogService
         bool actionButtonOnly
     );
 
-    Task<DialogResult> ShowConfirmationDialog(
+    Task<DialogResult> ShowConfirmationDialogAsync(
         string title,
         string description,
         string positiveButtonText,
@@ -90,7 +91,7 @@ public interface IDialogService
         ConfirmationType highlight
     );
 
-    Task<DialogResult> ShowInputDialog(
+    Task<DialogResult> ShowInputDialogAsync(
         string title,
         IEnumerable<InputField> fields,
         string description
@@ -134,53 +135,57 @@ public class DialogService(
         double maxHeight = double.NaN
     )
     {
-        if (dialog is ApplicationDialog.Information
-            or ApplicationDialog.Error
-            or ApplicationDialog.Confirmation
-            or ApplicationDialog.Input
-            or ApplicationDialog.Action)
+        Dispatcher.UIThread.Post(() =>
         {
-            throw new InvalidOperationException($"{dialog} dialog can not be used with ShowDialog.");
-        }
+            if (dialog is ApplicationDialog.Information
+                or ApplicationDialog.Error
+                or ApplicationDialog.Confirmation
+                or ApplicationDialog.Input
+                or ApplicationDialog.Action)
+            {
+                throw new InvalidOperationException($"{dialog} dialog can not be used with ShowDialog.");
+            }
 
-        var dialogWindow = new DialogWindow();
-        var dialogName = dialog + "View";
-        var type = typeof(DialogWindow).Assembly.GetType($"avallama.Views.Dialogs.{dialogName}");
-        if (type is null) return;
-        var control = (Control)Activator.CreateInstance(type)!;
-        control.DataContext = dialogViewModelFactory.GetDialogViewModel(dialog);
-        dialogWindow.DataContext = new DialogViewModel { DialogType = dialog };
-        dialogWindow.Content = control;
-        dialogWindow.CanResize = resizable;
+            var dialogWindow = new DialogWindow();
+            var dialogName = dialog + "View";
+            var type = typeof(DialogWindow).Assembly.GetType($"avallama.Views.Dialogs.{dialogName}");
+            if (type is null) return;
+            var control = (Control)Activator.CreateInstance(type)!;
+            control.DataContext = dialogViewModelFactory.GetDialogViewModel(dialog);
+            dialogWindow.DataContext = new DialogViewModel { DialogType = dialog };
+            dialogWindow.Content = control;
+            dialogWindow.CanResize = resizable;
 
-        // if we provide a height or width value, it will set the resizing accordingly
-        // so if we only provide width, it will adjust the height to the content and vice versa
-        if (double.IsNaN(width) && !double.IsNaN(height))
-        {
-            dialogWindow.SizeToContent = SizeToContent.Width;
-            dialogWindow.Height = height;
-        }
-        else if (!double.IsNaN(width) && double.IsNaN(height))
-        {
-            dialogWindow.SizeToContent = SizeToContent.Height;
-            dialogWindow.Width = width;
-        }
-        else if (!double.IsNaN(height) && !double.IsNaN(width))
-        {
-            dialogWindow.SizeToContent = SizeToContent.Manual;
-            dialogWindow.Height = height;
-            dialogWindow.Width = width;
-        }
+            // if we provide a height or width value, it will set the resizing accordingly
+            // so if we only provide width, it will adjust the height to the content and vice versa
+            if (double.IsNaN(width) && !double.IsNaN(height))
+            {
+                dialogWindow.SizeToContent = SizeToContent.Width;
+                dialogWindow.Height = height;
+            }
+            else if (!double.IsNaN(width) && double.IsNaN(height))
+            {
+                dialogWindow.SizeToContent = SizeToContent.Height;
+                dialogWindow.Width = width;
+            }
+            else if (!double.IsNaN(height) && !double.IsNaN(width))
+            {
+                dialogWindow.SizeToContent = SizeToContent.Manual;
+                dialogWindow.Height = height;
+                dialogWindow.Width = width;
+            }
 
-        if (resizable)
-        {
-            if (!double.IsNaN(minWidth)) dialogWindow.MinWidth = minWidth;
-            if (!double.IsNaN(minHeight)) dialogWindow.MinHeight = minHeight;
-            if (!double.IsNaN(maxWidth)) dialogWindow.MaxWidth = maxWidth;
-            if (!double.IsNaN(maxHeight)) dialogWindow.MaxHeight = maxHeight;
-        }
-        dialogWindow.InvalidateMeasure();
-        ShowDialogWindow(dialogWindow);
+            if (resizable)
+            {
+                if (!double.IsNaN(minWidth)) dialogWindow.MinWidth = minWidth;
+                if (!double.IsNaN(minHeight)) dialogWindow.MinHeight = minHeight;
+                if (!double.IsNaN(maxWidth)) dialogWindow.MaxWidth = maxWidth;
+                if (!double.IsNaN(maxHeight)) dialogWindow.MaxHeight = maxHeight;
+            }
+
+            dialogWindow.InvalidateMeasure();
+            ShowDialogWindow(dialogWindow);
+        });
     }
 
     /// <summary>
@@ -189,17 +194,20 @@ public class DialogService(
     /// <param name="informationMessage">The informational message to be shown.</param>
     public void ShowInfoDialog(string informationMessage)
     {
-        var dialogWindow = new DialogWindow();
-        var type = typeof(DialogWindow).Assembly.GetType("avallama.Views.Dialogs.InformationView");
-        if (type is null) return;
-        var control = (Control)Activator.CreateInstance(type)! as InformationView;
-        control!.DialogMessage.Text = informationMessage.Replace(@"\n", Environment.NewLine);
-        dialogWindow.Content = control;
-        dialogWindow.DataContext = new DialogViewModel
+        Dispatcher.UIThread.Post(() =>
         {
-            DialogType = ApplicationDialog.Information
-        };
-        ShowDialogWindow(dialogWindow);
+            var dialogWindow = new DialogWindow();
+            var type = typeof(DialogWindow).Assembly.GetType("avallama.Views.Dialogs.InformationView");
+            if (type is null) return;
+            var control = (Control)Activator.CreateInstance(type)! as InformationView;
+            control!.DialogMessage.Text = informationMessage.Replace(@"\n", Environment.NewLine);
+            dialogWindow.Content = control;
+            dialogWindow.DataContext = new DialogViewModel
+            {
+                DialogType = ApplicationDialog.Information
+            };
+            ShowDialogWindow(dialogWindow);
+        });
     }
 
     /// <summary>
@@ -212,26 +220,29 @@ public class DialogService(
         bool shutdownApp = false
     )
     {
-        var dialogWindow = new DialogWindow();
-        var type = typeof(DialogWindow).Assembly.GetType("avallama.Views.Dialogs.ErrorView");
-        if (type is null) return;
-        var control = (Control)Activator.CreateInstance(type)! as ErrorView;
-        control!.DialogMessage.Text = errorMessage.Replace(@"\n", Environment.NewLine);
-        control.CloseButton.Click += (_, _) =>
+        Dispatcher.UIThread.Post(() =>
         {
-            CloseDialog(ApplicationDialog.Error);
-            if (shutdownApp)
+            var dialogWindow = new DialogWindow();
+            var type = typeof(DialogWindow).Assembly.GetType("avallama.Views.Dialogs.ErrorView");
+            if (type is null) return;
+            var control = (Control)Activator.CreateInstance(type)! as ErrorView;
+            control!.DialogMessage.Text = errorMessage.Replace(@"\n", Environment.NewLine);
+            control.CloseButton.Click += (_, _) =>
             {
-                messenger.Send(new ApplicationMessage.Shutdown());
-            }
-        };
+                CloseDialog(ApplicationDialog.Error);
+                if (shutdownApp)
+                {
+                    messenger.Send(new ApplicationMessage.Shutdown());
+                }
+            };
 
-        dialogWindow.Content = control;
-        dialogWindow.DataContext = new DialogViewModel
-        {
-            DialogType = ApplicationDialog.Error
-        };
-        ShowDialogWindow(dialogWindow);
+            dialogWindow.Content = control;
+            dialogWindow.DataContext = new DialogViewModel
+            {
+                DialogType = ApplicationDialog.Error
+            };
+            ShowDialogWindow(dialogWindow);
+        });
     }
 
     /// <summary>
@@ -277,51 +288,54 @@ public class DialogService(
         bool actionButtonOnly = false
     )
     {
-        var dialogWindow = new DialogWindow();
-        // ConfirmationView on purpose, as its View is reusable
-        var type = typeof(DialogWindow).Assembly.GetType("avallama.Views.Dialogs.ConfirmationView");
-        if (type is null) return;
-        var control = (Control)Activator.CreateInstance(type)! as ConfirmationView;
+        Dispatcher.UIThread.Post(() =>
+        {
+            var dialogWindow = new DialogWindow();
+            // ConfirmationView on purpose, as its View is reusable
+            var type = typeof(DialogWindow).Assembly.GetType("avallama.Views.Dialogs.ConfirmationView");
+            if (type is null) return;
+            var control = (Control)Activator.CreateInstance(type)! as ConfirmationView;
 
-        control!.DialogTitle.Text = title;
-        if (!string.IsNullOrEmpty(description))
-        {
-            control.DialogDescription.Text = description;
-        }
-        else
-        {
-            control.DialogDescription.IsVisible = false;
-        }
+            control!.DialogTitle.Text = title;
+            if (!string.IsNullOrEmpty(description))
+            {
+                control.DialogDescription.Text = description;
+            }
+            else
+            {
+                control.DialogDescription.IsVisible = false;
+            }
 
-        control.PositiveButton.Content = actionButtonText;
-        if (actionButtonOnly)
-        {
-            control.NegativeButton.IsVisible = false;
-        }
-        else
-        {
-            control.NegativeButton.Content = LocalizationService.GetString("CLOSE");
-            control.NegativeButton.Classes.Add("secondaryButton");
-            control.NegativeButton.Click += (_, _) =>
+            control.PositiveButton.Content = actionButtonText;
+            if (actionButtonOnly)
+            {
+                control.NegativeButton.IsVisible = false;
+            }
+            else
+            {
+                control.NegativeButton.Content = LocalizationService.GetString("CLOSE");
+                control.NegativeButton.Classes.Add("secondaryButton");
+                control.NegativeButton.Click += (_, _) =>
+                {
+                    CloseDialog(ApplicationDialog.Action);
+                    closeAction?.Invoke();
+                };
+            }
+
+            control.PositiveButton.Click += (_, _) =>
             {
                 CloseDialog(ApplicationDialog.Action);
-                closeAction?.Invoke();
+                action();
             };
-        }
 
-        control.PositiveButton.Click += (_, _) =>
-        {
-            CloseDialog(ApplicationDialog.Action);
-            action();
-        };
+            dialogWindow.Content = control;
+            dialogWindow.DataContext = new DialogViewModel
+            {
+                DialogType = ApplicationDialog.Action
+            };
 
-        dialogWindow.Content = control;
-        dialogWindow.DataContext = new DialogViewModel
-        {
-            DialogType = ApplicationDialog.Action
-        };
-
-        ShowDialogWindow(dialogWindow);
+            ShowDialogWindow(dialogWindow);
+        });
     }
     // these methods have to be async because they have results that need to be awaited properly
     // if they were not async, they would try to await the result on the UI thread, causing it to freeze and preventing the result from being set with TrySetResult as the UI thread would already be busy
@@ -363,7 +377,7 @@ public class DialogService(
     /// }
     /// </code>
     /// </example>
-    public async Task<DialogResult> ShowConfirmationDialog(
+    public async Task<DialogResult> ShowConfirmationDialogAsync(
         string title,
         string positiveButtonText,
         string negativeButtonText,
@@ -371,65 +385,68 @@ public class DialogService(
         ConfirmationType highlight = ConfirmationType.Positive
     )
     {
-        var dialogResult = new TaskCompletionSource<DialogResult>();
-        var dialogWindow = new DialogWindow();
-        var type = typeof(DialogWindow).Assembly.GetType("avallama.Views.Dialogs.ConfirmationView");
-        if (type is null) return new NullResult("View type is null");
-        var control = (Control)Activator.CreateInstance(type)! as ConfirmationView;
+        return await Dispatcher.UIThread.InvokeAsync(async () =>
+        {
+            var dialogResult = new TaskCompletionSource<DialogResult>();
+            var dialogWindow = new DialogWindow();
+            var type = typeof(DialogWindow).Assembly.GetType("avallama.Views.Dialogs.ConfirmationView");
+            if (type is null) return new NullResult("View type is null");
+            var control = (Control)Activator.CreateInstance(type)! as ConfirmationView;
 
-        control!.DialogTitle.Text = title;
-        if (!string.IsNullOrEmpty(description))
-        {
-            control.DialogDescription.Text = description;
-        }
-        else
-        {
-            control.DialogDescription.IsVisible = false;
-        }
-
-        control.PositiveButton.Content = positiveButtonText;
-        control.NegativeButton.Content = negativeButtonText;
-
-        // if we want to highlight the positive button, then we give the negative button a less prominent appearance, and vice versa
-        // this class is already defined in styles
-        if (highlight == ConfirmationType.Positive)
-        {
-            control.NegativeButton.Classes.Add("secondaryButton");
-        }
-        else if (highlight == ConfirmationType.Negative)
-        {
-            control.PositiveButton.Classes.Add("secondaryButton");
-        }
-
-        control.PositiveButton.Click += (_, _) =>
-        {
-            dialogResult.TrySetResult(new ConfirmationResult(ConfirmationType.Positive));
-            CloseDialog(ApplicationDialog.Confirmation);
-        };
-
-        control.NegativeButton.Click += (_, _) =>
-        {
-            dialogResult.TrySetResult(new ConfirmationResult(ConfirmationType.Negative));
-            CloseDialog(ApplicationDialog.Confirmation);
-        };
-
-        dialogWindow.Content = control;
-        dialogWindow.DataContext = new DialogViewModel
-        {
-            DialogType = ApplicationDialog.Confirmation
-        };
-
-        // if a user closes the dialog in some other way, we handle the task
-        dialogWindow.Closing += (_, _) =>
-        {
-            if (!dialogResult.Task.IsCompleted)
+            control!.DialogTitle.Text = title;
+            if (!string.IsNullOrEmpty(description))
             {
-                dialogResult.TrySetResult(new NullResult("DialogWindow closed before returning result"));
+                control.DialogDescription.Text = description;
             }
-        };
-        await ShowDialogWindowAsync(dialogWindow);
-        var result = await dialogResult.Task;
-        return result;
+            else
+            {
+                control.DialogDescription.IsVisible = false;
+            }
+
+            control.PositiveButton.Content = positiveButtonText;
+            control.NegativeButton.Content = negativeButtonText;
+
+            // if we want to highlight the positive button, then we give the negative button a less prominent appearance, and vice versa
+            // this class is already defined in styles
+            if (highlight == ConfirmationType.Positive)
+            {
+                control.NegativeButton.Classes.Add("secondaryButton");
+            }
+            else if (highlight == ConfirmationType.Negative)
+            {
+                control.PositiveButton.Classes.Add("secondaryButton");
+            }
+
+            control.PositiveButton.Click += (_, _) =>
+            {
+                dialogResult.TrySetResult(new ConfirmationResult(ConfirmationType.Positive));
+                CloseDialog(ApplicationDialog.Confirmation);
+            };
+
+            control.NegativeButton.Click += (_, _) =>
+            {
+                dialogResult.TrySetResult(new ConfirmationResult(ConfirmationType.Negative));
+                CloseDialog(ApplicationDialog.Confirmation);
+            };
+
+            dialogWindow.Content = control;
+            dialogWindow.DataContext = new DialogViewModel
+            {
+                DialogType = ApplicationDialog.Confirmation
+            };
+
+            // if a user closes the dialog in some other way, we handle the task
+            dialogWindow.Closing += (_, _) =>
+            {
+                if (!dialogResult.Task.IsCompleted)
+                {
+                    dialogResult.TrySetResult(new NullResult("DialogWindow closed before returning result"));
+                }
+            };
+            await ShowDialogWindowAsync(dialogWindow);
+            var result = await dialogResult.Task;
+            return result;
+        });
     }
 
     /// <summary>
@@ -470,112 +487,115 @@ public class DialogService(
     /// }
     /// </code>
     /// </example>
-    public async Task<DialogResult> ShowInputDialog(
+    public async Task<DialogResult> ShowInputDialogAsync(
         string title,
         IEnumerable<InputField> inputFields,
         string description = ""
     )
     {
-        var fields = inputFields.ToList();
-        if (fields.Count == 0) return new NullResult("Empty input fields");
-
-        var dialogResult = new TaskCompletionSource<DialogResult>();
-        var dialogWindow = new DialogWindow();
-        var type = typeof(DialogWindow).Assembly.GetType("avallama.Views.Dialogs.InputView");
-        if (type is null) return new NullResult("View type is null");
-        var control = (Control)Activator.CreateInstance(type)! as InputView;
-
-        control!.DialogTitle.Text = title;
-        if (!string.IsNullOrEmpty(description))
+        return await Dispatcher.UIThread.InvokeAsync(async () =>
         {
-            control.DialogDescription.Text = description;
-        }
-        else
-        {
-            control.DialogDescription.IsVisible = false;
-        }
+            var fields = inputFields.ToList();
+            if (fields.Count == 0) return new NullResult("Empty input fields");
 
-        control.InputFieldsStackPanel.Children.Clear();
-        control.ErrorMessage.IsVisible = false;
+            var dialogResult = new TaskCompletionSource<DialogResult>();
+            var dialogWindow = new DialogWindow();
+            var type = typeof(DialogWindow).Assembly.GetType("avallama.Views.Dialogs.InputView");
+            if (type is null) return new NullResult("View type is null");
+            var control = (Control)Activator.CreateInstance(type)! as InputView;
 
-        foreach (var field in fields)
-        {
-            var inputTextBox = new TextBox();
-            inputTextBox.Classes.Add("settingTextBox");
-
-            if (field.IsPassword)
+            control!.DialogTitle.Text = title;
+            if (!string.IsNullOrEmpty(description))
             {
-                inputTextBox.PasswordChar = '*';
+                control.DialogDescription.Text = description;
+            }
+            else
+            {
+                control.DialogDescription.IsVisible = false;
             }
 
-            if (!string.IsNullOrEmpty(field.Placeholder))
-                inputTextBox.Watermark = field.Placeholder;
-
-            if (!string.IsNullOrEmpty(field.InputValue))
-                inputTextBox.Text = field.InputValue;
-
-            inputTextBox.MaxLength = field.MaxLength;
-            control.InputFieldsStackPanel.Children.Add(inputTextBox);
-        }
-
-        control.CloseButton.Click += (_, _) =>
-        {
-            // when closing the dialog without saving it does not return a result, as the user did not want to save anything
-            dialogResult.TrySetResult(new NullResult());
-            CloseDialog(ApplicationDialog.Input);
-        };
-
-        control.SaveButton.Click += (_, _) =>
-        {
+            control.InputFieldsStackPanel.Children.Clear();
             control.ErrorMessage.IsVisible = false;
-            control.ErrorMessage.Text = string.Empty;
 
-            // validation check
-            for (var i = 0; i < fields.Count; i++)
+            foreach (var field in fields)
             {
-                if (control.InputFieldsStackPanel.Children[i] is TextBox fieldTextBox)
+                var inputTextBox = new TextBox();
+                inputTextBox.Classes.Add("settingTextBox");
+
+                if (field.IsPassword)
                 {
-                    // we update the content of the input fields, so we can revalidate them
-                    fields[i].InputValue = fieldTextBox.Text ?? string.Empty;
+                    inputTextBox.PasswordChar = '*';
                 }
 
-                if (!fields[i].IsValid)
-                {
-                    control.ErrorMessage.IsVisible = true;
-                    control.ErrorMessage.Text = fields[i].ValidationErrorMessage;
-                    return;
-                }
+                if (!string.IsNullOrEmpty(field.Placeholder))
+                    inputTextBox.Watermark = field.Placeholder;
+
+                if (!string.IsNullOrEmpty(field.InputValue))
+                    inputTextBox.Text = field.InputValue;
+
+                inputTextBox.MaxLength = field.MaxLength;
+                control.InputFieldsStackPanel.Children.Add(inputTextBox);
             }
 
-            // the textboxes, or the input fields' texts are combined into a List<string>
-            var inputList = control.InputFieldsStackPanel.Children.Select(item =>
-                    item as TextBox
-                )
-                .OfType<TextBox>()
-                .Select(textBoxItem => textBoxItem.Text)
-                .ToList();
-
-            dialogResult.TrySetResult(new InputResult(inputList));
-            CloseDialog(ApplicationDialog.Input);
-        };
-
-        dialogWindow.Content = control;
-        dialogWindow.DataContext = new DialogViewModel
-        {
-            DialogType = ApplicationDialog.Input
-        };
-
-        // if the user closes the dialog in some other way, we handle the task
-        dialogWindow.Closing += (_, _) =>
-        {
-            if (!dialogResult.Task.IsCompleted)
+            control.CloseButton.Click += (_, _) =>
             {
-                dialogResult.TrySetResult(new NullResult("DialogWindow closed before returning result"));
-            }
-        };
-        await ShowDialogWindowAsync(dialogWindow);
-        var result = await dialogResult.Task;
-        return result;
+                // when closing the dialog without saving it does not return a result, as the user did not want to save anything
+                dialogResult.TrySetResult(new NullResult());
+                CloseDialog(ApplicationDialog.Input);
+            };
+
+            control.SaveButton.Click += (_, _) =>
+            {
+                control.ErrorMessage.IsVisible = false;
+                control.ErrorMessage.Text = string.Empty;
+
+                // validation check
+                for (var i = 0; i < fields.Count; i++)
+                {
+                    if (control.InputFieldsStackPanel.Children[i] is TextBox fieldTextBox)
+                    {
+                        // we update the content of the input fields, so we can revalidate them
+                        fields[i].InputValue = fieldTextBox.Text ?? string.Empty;
+                    }
+
+                    if (!fields[i].IsValid)
+                    {
+                        control.ErrorMessage.IsVisible = true;
+                        control.ErrorMessage.Text = fields[i].ValidationErrorMessage;
+                        return;
+                    }
+                }
+
+                // the textboxes, or the input fields' texts are combined into a List<string>
+                var inputList = control.InputFieldsStackPanel.Children.Select(item =>
+                        item as TextBox
+                    )
+                    .OfType<TextBox>()
+                    .Select(textBoxItem => textBoxItem.Text)
+                    .ToList();
+
+                dialogResult.TrySetResult(new InputResult(inputList));
+                CloseDialog(ApplicationDialog.Input);
+            };
+
+            dialogWindow.Content = control;
+            dialogWindow.DataContext = new DialogViewModel
+            {
+                DialogType = ApplicationDialog.Input
+            };
+
+            // if the user closes the dialog in some other way, we handle the task
+            dialogWindow.Closing += (_, _) =>
+            {
+                if (!dialogResult.Task.IsCompleted)
+                {
+                    dialogResult.TrySetResult(new NullResult("DialogWindow closed before returning result"));
+                }
+            };
+            await ShowDialogWindowAsync(dialogWindow);
+            var result = await dialogResult.Task;
+            return result;
+        });
     }
 
     /// <summary>
@@ -585,28 +605,31 @@ public class DialogService(
     /// <param name="dialogWindow">The dialog window to be displayed.</param>
     private void ShowDialogWindow(DialogWindow dialogWindow)
     {
-        var parent = _dialogStack.Count > 0
-            ? _dialogStack.Peek()
-            : Application.Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop
-                ? desktop.MainWindow
-                : null;
-        if (parent == null)
+        Dispatcher.UIThread.Post(() =>
         {
-            dialogWindow.Show();
-        }
-        else
-        {
-            dialogWindow.ShowDialog(parent);
-        }
-
-        _dialogStack.Push(dialogWindow);
-        dialogWindow.Closing += (_, _) =>
-        {
-            if (_dialogStack.Peek() == dialogWindow)
-                _dialogStack.Pop();
+            var parent = _dialogStack.Count > 0
+                ? _dialogStack.Peek()
+                : Application.Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop
+                    ? desktop.MainWindow
+                    : null;
+            if (parent == null)
+            {
+                dialogWindow.Show();
+            }
             else
-                _dialogStack = new Stack<DialogWindow>(_dialogStack.Where(w => w != dialogWindow));
-        };
+            {
+                dialogWindow.ShowDialog(parent);
+            }
+
+            _dialogStack.Push(dialogWindow);
+            dialogWindow.Closing += (_, _) =>
+            {
+                if (_dialogStack.Peek() == dialogWindow)
+                    _dialogStack.Pop();
+                else
+                    _dialogStack = new Stack<DialogWindow>(_dialogStack.Where(w => w != dialogWindow));
+            };
+        });
     }
 
     /// <summary>
@@ -619,30 +642,33 @@ public class DialogService(
     /// </returns>
     private async Task ShowDialogWindowAsync(DialogWindow dialogWindow)
     {
-        var parent = _dialogStack.Count > 0
-            ? _dialogStack.Peek()
-            : Application.Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop
-                ? desktop.MainWindow
-                : null;
+        await Dispatcher.UIThread.InvokeAsync(async () =>
+        {
+            var parent = _dialogStack.Count > 0
+                ? _dialogStack.Peek()
+                : Application.Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop
+                    ? desktop.MainWindow
+                    : null;
 
-        _dialogStack.Push(dialogWindow);
-        dialogWindow.Closing += (_, _) =>
-        {
-            if (_dialogStack.Peek() == dialogWindow)
-                _dialogStack.Pop();
+            _dialogStack.Push(dialogWindow);
+            dialogWindow.Closing += (_, _) =>
+            {
+                if (_dialogStack.Peek() == dialogWindow)
+                    _dialogStack.Pop();
+                else
+                    _dialogStack = new Stack<DialogWindow>(_dialogStack.Where(w => w != dialogWindow));
+            };
+            // it's important that the dialog display with await is the last thing, because with await it will wait until the dialog is closed
+            // and if we do not set up the dialog before (adding to stack, adding closing operations) then it cannot be closed
+            if (parent == null)
+            {
+                dialogWindow.Show();
+            }
             else
-                _dialogStack = new Stack<DialogWindow>(_dialogStack.Where(w => w != dialogWindow));
-        };
-        // it's important that the dialog display with await is the last thing, because with await it will wait until the dialog is closed
-        // and if we do not set up the dialog before (adding to stack, adding closing operations) then it cannot be closed
-        if (parent == null)
-        {
-            dialogWindow.Show();
-        }
-        else
-        {
-            await dialogWindow.ShowDialog(parent);
-        }
+            {
+                await dialogWindow.ShowDialog(parent);
+            }
+        });
     }
 
     /// <summary>
@@ -651,11 +677,14 @@ public class DialogService(
     /// <param name="dialog">The type of dialog to close.</param>
     public void CloseDialog(ApplicationDialog dialog)
     {
-        var dialogWindow = _dialogStack.FirstOrDefault(d => d.DataContext is DialogViewModel viewModel
-                                                            && viewModel.DialogType == dialog);
-        if (dialogWindow == null) return;
-        dialogWindow.Close();
-        _dialogStack = new Stack<DialogWindow>(_dialogStack.Where(w => w != dialogWindow));
+        Dispatcher.UIThread.Post(() =>
+        {
+            var dialogWindow = _dialogStack.FirstOrDefault(d => d.DataContext is DialogViewModel viewModel
+                                                                && viewModel.DialogType == dialog);
+            if (dialogWindow == null) return;
+            dialogWindow.Close();
+            _dialogStack = new Stack<DialogWindow>(_dialogStack.Where(w => w != dialogWindow));
+        });
     }
 
     /// <summary>
@@ -663,9 +692,12 @@ public class DialogService(
     /// </summary>
     public void CloseDialog()
     {
-        if (_dialogStack.Count <= 0) return;
-        var dialogWindow = _dialogStack.Pop();
-        dialogWindow.Close();
+        Dispatcher.UIThread.Post(() =>
+        {
+            if (_dialogStack.Count <= 0) return;
+            var dialogWindow = _dialogStack.Pop();
+            dialogWindow.Close();
+        });
     }
 
     /// <summary>
@@ -673,11 +705,14 @@ public class DialogService(
     /// </summary>
     public void CloseAllDialogs()
     {
-        foreach (var dialogWindow in _dialogStack.ToList())
+        Dispatcher.UIThread.Post(() =>
         {
-            dialogWindow.Close();
-        }
+            foreach (var dialogWindow in _dialogStack.ToList())
+            {
+                dialogWindow.Close();
+            }
 
-        _dialogStack.Clear();
+            _dialogStack.Clear();
+        });
     }
 }

--- a/avallama/Services/Ollama/OllamaProcessManager.cs
+++ b/avallama/Services/Ollama/OllamaProcessManager.cs
@@ -129,7 +129,7 @@ public class OllamaProcessManager : IOllamaProcessManager, IDisposable
         {
             Status = new OllamaProcessStatus(OllamaProcessLifecycle.Starting);
 
-            ConfigureOllamaPath();
+            OllamaPath = GetOllamaExecutablePath();
 
             // check for existing instances (real server processes).
             // we get all processes named "ollama" and ensure they don't have a window handle
@@ -286,18 +286,29 @@ public class OllamaProcessManager : IOllamaProcessManager, IDisposable
         _ollamaProcess = null;
     }
 
-    private void ConfigureOllamaPath()
+    private string GetOllamaExecutablePath()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        var executableName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "ollama.exe" : "ollama";
+
+        var pathVariable = Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
+
+        if (string.IsNullOrEmpty(pathVariable)) return string.Empty;
+
+        var paths = pathVariable.Split(Path.PathSeparator);
+
+        foreach (var path in paths)
         {
-            OllamaPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                @"Programs\Ollama\ollama");
+            if (string.IsNullOrWhiteSpace(path)) continue;
+
+            var fullPath = Path.Combine(path.Trim(), executableName);
+
+            if (File.Exists(fullPath))
+            {
+                return fullPath;
+            }
         }
-        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ||
-                 RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-        {
-            OllamaPath = @"/usr/local/bin/ollama";
-        }
+
+        return string.Empty;
     }
 
     private static bool IsOllamaRunningAsSystemdService()

--- a/avallama/Styles/ToggleSwitch.axaml
+++ b/avallama/Styles/ToggleSwitch.axaml
@@ -18,7 +18,7 @@ Licensed under the MIT License. See LICENSE file for details.
         <Setter Property="Foreground" Value="{DynamicResource OnSurface}" />
         <Setter Property="OffContent" Value="{services:LocalizationService Key='OFF'}"/>
         <Setter Property="OnContent" Value="{services:LocalizationService Key='ON'}"/>
-        <Setter Property="FlowDirection" Value="RightToLeft"/>
+        <Setter Property="FlowDirection" Value="LeftToRight"/>
 
         <!-- Checked styles -->
         <Style Selector="^:checked  /template/ Border#SwitchKnobBounds">

--- a/avallama/ViewModels/HomeViewModel.cs
+++ b/avallama/ViewModels/HomeViewModel.cs
@@ -18,6 +18,7 @@ using avallama.Services;
 using avallama.Services.Ollama;
 using avallama.Services.Persistence;
 using avallama.Utilities;
+using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
@@ -300,7 +301,7 @@ public partial class HomeViewModel : PageViewModel
     {
         if (parameter is not Guid guid || SelectedConversation == null || Conversations == null) return;
 
-        var res = await _dialogService.ShowConfirmationDialog(
+        var res = await _dialogService.ShowConfirmationDialogAsync(
             LocalizationService.GetString("CONFIRM_DELETION_DIALOG_TITLE"),
             LocalizationService.GetString("DELETE"),
             LocalizationService.GetString("CANCEL"),
@@ -695,7 +696,6 @@ public partial class HomeViewModel : PageViewModel
                     _checkForApiStatus = true;
                     return;
                 }
-
                 _dialogService.ShowActionDialog(
                     title: LocalizationService.GetString("OLLAMA_NOT_INSTALLED"),
                     actionButtonText: LocalizationService.GetString("DOWNLOAD"),

--- a/avallama/ViewModels/MainViewModel.cs
+++ b/avallama/ViewModels/MainViewModel.cs
@@ -94,7 +94,7 @@ public partial class MainViewModel : ViewModelBase
         if (models.Count == 0 && (string.IsNullOrEmpty(isScrapeDialogHandled) || isScrapeDialogHandled == "False"))
         {
             // ask the user if they want to fetch all models from ollama's website if they haven't been asked before
-            var dialogResult = await _dialogService.ShowConfirmationDialog(
+            var dialogResult = await _dialogService.ShowConfirmationDialogAsync(
                 LocalizationService.GetString("SCRAPE_ASK_DIALOG_TITLE"),
                 LocalizationService.GetString("SCRAPE_ASK_DIALOG_POSITIVE"),
                 LocalizationService.GetString("NOT_NOW"),

--- a/avallama/ViewModels/ModelItemViewModel.cs
+++ b/avallama/ViewModels/ModelItemViewModel.cs
@@ -138,7 +138,7 @@ public partial class ModelItemViewModel : ViewModelBase
         // TODO: add a force delete option in case data is somehow corrupted and throws error while deleting
 
         if (!Model.IsDownloaded) return;
-        var dialogResult = await _dialogService.ShowConfirmationDialog(
+        var dialogResult = await _dialogService.ShowConfirmationDialogAsync(
             LocalizationService.GetString("CONFIRM_DELETION_DIALOG_TITLE"),
             LocalizationService.GetString("DELETE"),
             LocalizationService.GetString("CANCEL"),

--- a/avallama/ViewModels/SettingsViewModel.cs
+++ b/avallama/ViewModels/SettingsViewModel.cs
@@ -43,7 +43,7 @@ public partial class SettingsViewModel : PageViewModel
                 // asynchronously show restart dialog on the UI thread
                 Dispatcher.UIThread.InvokeAsync(async () =>
                 {
-                    var dialogResult = await _dialogService.ShowConfirmationDialog(
+                    var dialogResult = await _dialogService.ShowConfirmationDialogAsync(
                         title: LocalizationService.GetString("RESTART_NEEDED_DIALOG_TITLE"),
                         positiveButtonText: LocalizationService.GetString("RESTART_NOW"),
                         negativeButtonText: LocalizationService.GetString("LATER"),

--- a/avallama/avallama.csproj
+++ b/avallama/avallama.csproj
@@ -30,7 +30,7 @@ Licensed under the MIT License. See LICENSE file for details.
 
     <!-- Versions -->
     <PropertyGroup>
-        <AvaloniaVersion>11.3.9</AvaloniaVersion>
+        <AvaloniaVersion>11.3.16</AvaloniaVersion>
         <DotNetLibVersion>10.0.0</DotNetLibVersion>
     </PropertyGroup>
 


### PR DESCRIPTION
### Changes
- Resolved an issue where dialogs initialized on a background thread caused an `NSInternalInconsistencyException` on macOS.
- Improved Ollama path retrieval. The path is now being fetched from the environment `PATH` variable, replacing the previous hardcoded values.
- Changed the flow direction of `ToggleSwitch` elements from `RightToLeft` to `LeftToRight` to align with standard UI conventions.

This PR also includes the missing commits that needs to be merged into the dev branch.