### PR TITLE
Update CI workflows

### DIFF
--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -1,20 +1,15 @@
-﻿name: Release Avallama (Test)
+﻿name: Continuous Test and Package Build
 
 on:
+  push:
+    branches: [ main ]
   schedule:
-    - cron: '30 18 * * 5'
-  workflow_dispatch:
-    inputs:
-      version:
-        description: 'Version number (without v prefix)'
-        required: true
-        default: '0.0.1'
+    - cron: '30 18 * * 5' # Every Friday at 18:30 UTC
 
 env:
   DOTNET_CLI_TELEMETRY_OPTOUT: "1"
   DOTNET_NOLOGO: "true"
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: "1"
-  RELEASE_VERSION: ${{ github.event.inputs.version || '0.0.0' }}
 
 permissions:
   contents: read
@@ -86,7 +81,6 @@ jobs:
       - name: Build Installer
         run: |
           & "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" `
-            /DAppVersion="${{ env.RELEASE_VERSION }}" `
             scripts\installer.iss
 
   build-debian:
@@ -105,7 +99,7 @@ jobs:
       - name: Run Debian packaging script
         run: |
           chmod +x scripts/package-debian.sh
-          ./scripts/package-debian.sh "${{ env.RELEASE_VERSION }}"
+          ./scripts/package-debian.sh
 
   build-arch:
     name: (Release Test) Build Arch Package
@@ -131,7 +125,7 @@ jobs:
           cp -r avallama /tmp/build/
           cp -r scripts /tmp/build/
           chown -R builder:builder /tmp/build
-          sudo -u builder bash -c "cd /tmp/build && chmod +x scripts/package-arch.sh && scripts/package-arch.sh '${{ env.RELEASE_VERSION }}'"
+          sudo -u builder bash -c "cd /tmp/build && chmod +x scripts/package-arch.sh && scripts/package-arch.sh"
 
 
   build-macos:
@@ -153,4 +147,4 @@ jobs:
       - name: Run macOS packaging script
         run: |
           chmod +x scripts/package-macos.sh
-          ./scripts/package-macos.sh "${{ env.RELEASE_VERSION }}"
+          ./scripts/package-macos.sh

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,0 +1,110 @@
+﻿name: PR Package Build
+
+on:
+  pull_request:
+    branches: [ main ]
+
+env:
+  DOTNET_CLI_TELEMETRY_OPTOUT: "1"
+  DOTNET_NOLOGO: "true"
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: "1"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  build-windows:
+    name: Windows Installer (PR, x64)
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.x'
+
+      - name: Restore & Publish
+        run: dotnet publish avallama/avallama.csproj -c Release -r win-x64 --self-contained true -o win-dist /p:PublishSingleFile=true
+
+      - name: Install Inno Setup
+        shell: pwsh
+        run: |
+          Invoke-WebRequest https://jrsoftware.org/download.php/is.exe -OutFile is.exe
+          Start-Process -FilePath .\is.exe -ArgumentList '/VERYSILENT', '/SUPPRESSMSGBOXES' -Wait
+          echo "C:\Program Files (x86)\Inno Setup 6" >> $env:GITHUB_PATH
+
+      - name: Build Installer
+        shell: pwsh
+        run: |
+          & "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" `
+            scripts\installer.iss
+
+      - name: Upload Windows installer artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: avallama-windows-x64-pr-${{ github.event.pull_request.number }}
+          path: |
+            scripts/avallama-*.exe
+          retention-days: 7
+          if-no-files-found: error
+
+  build-debian:
+    name: Debian Package (PR, x64)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.x'
+
+      - name: Run Debian packaging script
+        run: |
+          chmod +x scripts/package-debian.sh
+          ./scripts/package-debian.sh
+
+      - name: Upload Debian package artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: avallama-debian-x64-pr-${{ github.event.pull_request.number }}
+          path: |
+            *.deb
+          retention-days: 7
+          if-no-files-found: error
+
+  build-macos:
+    name: macOS Package (PR, arm64)
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.x'
+
+      - name: Install create-dmg tool
+        run: brew install create-dmg
+
+      - name: Run macOS packaging script
+        run: |
+          chmod +x scripts/package-macos-pr.sh
+          ./scripts/package-macos-pr.sh
+
+      - name: Upload macOS package artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: avallama-macos-arm64-pr-${{ github.event.pull_request.number }}
+          path: |
+            *.dmg
+          retention-days: 7
+          if-no-files-found: error

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -1,8 +1,6 @@
-name: Build and Test
+﻿name: PR Test
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
     branches: [ main ]
 
@@ -15,7 +13,7 @@ concurrency:
 
 jobs:
   build-and-test:
-    name: Build and Test (${{ matrix.os }})
+    name: Test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -27,6 +25,7 @@ jobs:
     env:
       DOTNET_CLI_TELEMETRY_OPTOUT: "1"
       DOTNET_NOLOGO: "true"
+      DOTNET_SKIP_FIRST_TIME_EXPERIENCE: "1"
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -64,6 +63,8 @@ jobs:
           path: |
             **/TestResults/*.trx
             **/TestResults/*
+          retention-days: 1
+          if-no-files-found: warn
 
       - name: Upload coverage artifacts
         if: always()
@@ -72,6 +73,8 @@ jobs:
           name: coverage-${{ matrix.os }}
           path: |
             **/TestResults/*/coverage.cobertura.xml
+          retention-days: 1
+          if-no-files-found: warn
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de

--- a/README.md
+++ b/README.md
@@ -4,11 +4,17 @@
 <h1 align="center">Avallama</h1>
 
 <p align="center">
-  <a href="https://github.com/4foureyes/avallama/actions/workflows/pr.yml">
-    <img alt="Build" src="https://github.com/4foureyes/avallama/actions/workflows/pr.yml/badge.svg?branch=main">
+  <a href="https://github.com/4foureyes/avallama/actions/workflows/pr-build.yml">
+    <img alt="PR Build Badge" src="https://github.com/4foureyes/avallama/actions/workflows/pr-build.yml/badge.svg?branch=main">
+  </a>
+  <a href="https://github.com/4foureyes/avallama/actions/workflows/pr-test.yml">
+    <img alt="PR Test Badge" src="https://github.com/4foureyes/avallama/actions/workflows/pr-test.yml/badge.svg?branch=main">
+  </a>
+  <a href="https://github.com/4foureyes/avallama/actions/workflows/continuous.yml">
+    <img alt="Continuous Build Badge" src="https://github.com/4foureyes/avallama/actions/workflows/continuous.yml/badge.svg?branch=main">
   </a>
   <a href="https://codecov.io/gh/4foureyes/avallama">
-    <img alt="Coverage" src="https://codecov.io/gh/4foureyes/avallama/branch/main/graph/badge.svg">
+    <img alt="Coverage Badge" src="https://codecov.io/gh/4foureyes/avallama/branch/main/graph/badge.svg">
   </a>
 </p>
 

--- a/scripts/package-arch.sh
+++ b/scripts/package-arch.sh
@@ -6,11 +6,8 @@ log()    { printf '%s [INFO] %s\n' "$(log_ts)" "$*"; }
 
 log "Starting Arch package script"
 
-VERSION="${1:-}"
-if [ -z "$VERSION" ]; then
-  echo "Usage: $0 <version>"
-  exit 1
-fi
+VERSION="${1:-0.0.0}"
+log "Using version: $VERSION"
 
 PROJECT="./avallama/avallama.csproj"
 

--- a/scripts/package-debian.sh
+++ b/scripts/package-debian.sh
@@ -6,11 +6,8 @@ log()    { printf '%s [INFO] %s\n' "$(log_ts)" "$*"; }
 
 log "Starting Debian package script"
 
-VERSION="${1:-}"
-if [ -z "$VERSION" ]; then
-  echo "Usage: $0 <version>"
-  exit 1
-fi
+VERSION="${1:-0.0.0}"
+log "Using version: $VERSION"
 
 PROJECT="avallama/avallama.csproj"
 

--- a/scripts/package-macos-pr.sh
+++ b/scripts/package-macos-pr.sh
@@ -1,5 +1,8 @@
-#!/usr/bin/env bash
+﻿#!/usr/bin/env bash
 set -euo pipefail
+
+# macOS packaging script that only builds for arm64 for use in PRs.
+# Do not use to release! It does not build for x86_64.
 
 log_ts() { date -u +"%Y-%m-%dT%H:%M:%SZ"; }
 log()    { printf '%s [INFO] %s\n' "$(log_ts)" "$*"; }
@@ -21,11 +24,9 @@ if [ ! -f "$NATIVE_SRC" ]; then
 fi
 
 log "Compiling native macOS source code"
-# compiles native macOS source code to create a universal dylib binary
-clang -dynamiclib -framework Cocoa -arch x86_64 -arch arm64 -o "$DYLIB_OUTPUT" "$NATIVE_SRC"
+# compiles native macOS source code to create a dylib binary
+clang -dynamiclib -framework Cocoa -arch arm64 -o "$DYLIB_OUTPUT" "$NATIVE_SRC"
 
-log "Running dotnet publish for osx-x64"
-dotnet publish "$PROJECT" -v n -c Release -r osx-x64 --self-contained true -o mac-dist-x64 /p:PublishSingleFile=true
 log "Running dotnet publish for osx-arm64"
 dotnet publish "$PROJECT" -v n -c Release -r osx-arm64 --self-contained true -o mac-dist-arm64 /p:PublishSingleFile=true
 
@@ -38,7 +39,7 @@ create_app_structure() {
   cp avallama/Assets/Avallama.icns "$output_app/Contents/Resources"
 
   log "[create_app_structure()] Adding universal dylib to .app for ${arch_dir}"
-  # includes the compiled universal dylib in the .app
+  # includes the compiled dylib in the .app
   cp "$DYLIB_OUTPUT" "$output_app/Contents/MacOS/"
   chmod +x "$output_app/Contents/MacOS/libFullScreenCheck.dylib"
 
@@ -107,14 +108,6 @@ create_installer_dmg() {
       "$app_name"
 }
 
-# x64
-rm -rf Avallama.app
-log "Creating .app structure for x64"
-create_app_structure "mac-dist-x64" "Avallama.app"
-# zip -r "avallama_${VERSION}_osx_x64.zip" Avallama.app
-log "Creating DMG installer for x64"
-create_installer_dmg "x64"
-
 # arm64
 rm -rf Avallama.app
 log "Creating .app structure for arm64"
@@ -129,4 +122,4 @@ rm -rf Avallama.app
 rm -rf mac-dist-*
 rm -rf $DYLIB_OUTPUT
 
-log "Done: Created avallama_${VERSION}_osx_x64.dmg and avallama_${VERSION}_osx_arm64.dmg"
+log "Done: Created avallama_${VERSION}_osx_arm64.dmg"


### PR DESCRIPTION
Updated the CI workflows to support new branching strategy and more robust checks.

New workflow setup:
- `Continuous`: Runs on every push to `main` and on every Friday at 18:30 UTC
    - Runs unit tests on all three major platforms (Windows, Linux (Ubuntu), macOS)
    - Builds the packages for Windows, Debian/Ubuntu, Arch Linux & macOS (arm64 & x64)
    - Does not upload artifacts
    - This is essentially the release workflow except no release is created
- `pr-build`: Runs on every PR opened to `main`
    - Builds the packages for Windows, Debian/Ubuntu & macOS (arm64 only)
    - Uploads the packages as artifacts with a retention of 7 days, so the PR can easily be tested in its packaged form
- `pr-test`: Runs on every PR opened to `main`
    - Runs unit tests on all three major platforms (Windows, Linux (Ubuntu), macOS)
    - Uploads coverage artifacts to codecov

The `pr-build` and `pr-test` are separated and run in parallel. The release workflow remains unchanged