### PR TITLE
Unified `OllamaService` status for UI layer + minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,10 @@ cd ~/Downloads
 3. Install the package using the following command:
 
 ```bash
-sudo apt install ./avallama_0.3.1_amd64.deb
+sudo apt install ./avallama_0.3.2_amd64.deb
 ```
 
-*Replace `./avallama_0.3.1_amd64.deb` with the correct filename of the latest package*
+*Replace `./avallama_0.3.2_amd64.deb` with the correct filename of the latest package*
 
 4. After that, you can run the application from the application menu or with the `avallama` command
 
@@ -77,10 +77,10 @@ sudo apt remove avallama
 3. Install the package using the following command:
 
 ```bash
-sudo pacman -U avallama-0.3.1-1-x86_64.pkg.tar.zst
+sudo pacman -U avallama-0.3.2-1-x86_64.pkg.tar.zst
 ```
 
-*Replace `avallama-0.3.1-1-x86_64.pkg.tar.zst` with the correct filename of the latest package*
+*Replace `avallama-0.3.2-1-x86_64.pkg.tar.zst` with the correct filename of the latest package*
 
 To uninstall run:
 
@@ -98,7 +98,7 @@ sudo pacman -Rns avallama
 
 The Windows installer is **not signed with a trusted code-signing certificate**, so Windows SmartScreen may prevent it from running. If you wish to circumvent this, click `More info -> Run anyway`.
 
-1. Download the latest Windows installer from the [releases](https://github.com/4foureyes/avallama/releases) page, e.g. `avallama-setup-0.3.1.exe`.
+1. Download the latest Windows installer from the [releases](https://github.com/4foureyes/avallama/releases) page, e.g. `avallama-setup-0.3.2.exe`.
 2. Open the installer and go through the setup steps.
 3. Once installed, you can run the application from the Start Menu.
 

--- a/avallama.Tests/Fixtures/TestServicesFixture.cs
+++ b/avallama.Tests/Fixtures/TestServicesFixture.cs
@@ -14,8 +14,8 @@ namespace avallama.Tests.Fixtures;
 public class TestServicesFixture
 {
     public Mock<IOllamaService> OllamaMock { get; } = new();
-    public Mock<IOllamaApiClient> OllamaApiClientMock { get; } = new();
-    public Mock<IOllamaProcessManager> OllamaProcessManagerMock { get; } = new();
+    internal Mock<IOllamaApiClient> OllamaApiClientMock { get; } = new();
+    internal Mock<IOllamaProcessManager> OllamaProcessManagerMock { get; } = new();
     public Mock<IDialogService> DialogMock { get; } = new();
     public Mock<IConfigurationService> ConfigMock { get; } = new();
     public Mock<IConversationService> DbMock { get; } = new();

--- a/avallama.Tests/Services/Ollama/OllamaApiClientTests.cs
+++ b/avallama.Tests/Services/Ollama/OllamaApiClientTests.cs
@@ -86,7 +86,7 @@ public class OllamaApiClientTests : IClassFixture<TestServicesFixture>
         var delayerMock = new TaskDelayerMock(timeMock);
 
         var callCount = 0;
-        var stateEvents = new List<OllamaConnectionState?>();
+        var stateEvents = new List<OllamaApiState?>();
 
         _handlerMock
             .Protected()
@@ -116,12 +116,12 @@ public class OllamaApiClientTests : IClassFixture<TestServicesFixture>
 
         var oac = CreateOllamaApiClient(mockHttpClientFactory.Object, timeMock, delayerMock);
 
-        oac.StatusChanged += status => { stateEvents.Add(status.ConnectionState); };
+        oac.StatusChanged += status => { stateEvents.Add(status.ApiState); };
 
         await oac.CheckConnectionAsync();
 
-        Assert.Equal(1, stateEvents.Count(e => e == OllamaConnectionState.Connected));
-        Assert.Equal(1, stateEvents.Count(e => e == OllamaConnectionState.Reconnecting));
+        Assert.Equal(1, stateEvents.Count(e => e == OllamaApiState.Connected));
+        Assert.Equal(1, stateEvents.Count(e => e == OllamaApiState.Reconnecting));
         Assert.Equal(4, callCount);
         Assert.True(timeMock.Elapsed.TotalMilliseconds >= 100);
     }
@@ -152,14 +152,14 @@ public class OllamaApiClientTests : IClassFixture<TestServicesFixture>
 
         var oac = CreateOllamaApiClient(mockHttpClientFactory.Object, timeMock, delayerMock);
 
-        var stateEvents = new List<OllamaConnectionState?>();
-        oac.StatusChanged += status => { stateEvents.Add(status.ConnectionState); };
+        var stateEvents = new List<OllamaApiState?>();
+        oac.StatusChanged += status => { stateEvents.Add(status.ApiState); };
 
         await oac.CheckConnectionAsync();
 
-        Assert.Equal(OllamaConnectionState.Connecting, stateEvents[0]);
-        Assert.Equal(OllamaConnectionState.Reconnecting, stateEvents[1]);
-        Assert.Equal(OllamaConnectionState.Faulted, stateEvents[2]);
+        Assert.Equal(OllamaApiState.Connecting, stateEvents[0]);
+        Assert.Equal(OllamaApiState.Reconnecting, stateEvents[1]);
+        Assert.Equal(OllamaApiState.Failed, stateEvents[2]);
         Assert.Equal(3, stateEvents.Count);
         Assert.True(callCount > 1, $"Expected multiple calls, but got {callCount}");
     }
@@ -204,15 +204,15 @@ public class OllamaApiClientTests : IClassFixture<TestServicesFixture>
 
         var oac = CreateOllamaApiClient(mockHttpClientFactory.Object, timeMock, delayerMock);
 
-        var stateEvents = new List<OllamaConnectionState?>();
-        oac.StatusChanged += status => { stateEvents.Add(status.ConnectionState); };
+        var stateEvents = new List<OllamaApiState?>();
+        oac.StatusChanged += status => { stateEvents.Add(status.ApiState); };
 
         await oac.CheckConnectionAsync();
 
         Assert.Equal(2, callCount);
-        Assert.Equal(OllamaConnectionState.Connecting, stateEvents[0]);
-        Assert.Equal(OllamaConnectionState.Reconnecting, stateEvents[1]);
-        Assert.Equal(OllamaConnectionState.Connected, oac.Status.ConnectionState);
+        Assert.Equal(OllamaApiState.Connecting, stateEvents[0]);
+        Assert.Equal(OllamaApiState.Reconnecting, stateEvents[1]);
+        Assert.Equal(OllamaApiState.Connected, oac.Status.ApiState);
     }
 
     [Fact]
@@ -272,8 +272,8 @@ public class OllamaApiClientTests : IClassFixture<TestServicesFixture>
 
         var oac = CreateOllamaApiClient(mockHttpClientFactory.Object, timeMock, delayerMock);
 
-        var stateEvents = new List<OllamaConnectionState?>();
-        oac.StatusChanged += status => { stateEvents.Add(status.ConnectionState); };
+        var stateEvents = new List<OllamaApiState?>();
+        oac.StatusChanged += status => { stateEvents.Add(status.ApiState); };
 
         await oac.CheckConnectionAsync();
 
@@ -287,7 +287,7 @@ public class OllamaApiClientTests : IClassFixture<TestServicesFixture>
         Assert.Equal("Hello", results[0].Message?.Content);
         Assert.Equal("World!", results[1].Message?.Content);
 
-        Assert.Contains(stateEvents, state => state == OllamaConnectionState.Connected);
+        Assert.Contains(stateEvents, state => state == OllamaApiState.Connected);
     }
 
     [Fact]
@@ -369,15 +369,15 @@ public class OllamaApiClientTests : IClassFixture<TestServicesFixture>
 
         var oac = CreateOllamaApiClient(mockHttpClientFactory.Object, timeMock, delayerMock);
 
-        var stateEvents = new List<OllamaConnectionState?>();
-        oac.StatusChanged += status => { stateEvents.Add(status.ConnectionState); };
+        var stateEvents = new List<OllamaApiState?>();
+        oac.StatusChanged += status => { stateEvents.Add(status.ApiState); };
 
         await foreach (var _ in oac.GenerateMessageAsync([], "model"))
         {
         }
 
-        Assert.Equal(OllamaConnectionState.Faulted, oac.Status.ConnectionState);
-        Assert.Contains(OllamaConnectionState.Faulted, stateEvents);
+        Assert.Equal(OllamaApiState.Failed, oac.Status.ApiState);
+        Assert.Contains(OllamaApiState.Failed, stateEvents);
     }
 
     [Fact]
@@ -451,8 +451,8 @@ public class OllamaApiClientTests : IClassFixture<TestServicesFixture>
 
         Assert.Single(results);
         Assert.Equal("Finally loaded!", results[0].Message?.Content);
-        Assert.NotEqual(OllamaConnectionState.Disconnected, oac.Status.ConnectionState);
-        Assert.NotEqual(OllamaConnectionState.Faulted, oac.Status.ConnectionState);
+        Assert.NotEqual(OllamaApiState.Disconnected, oac.Status.ApiState);
+        Assert.NotEqual(OllamaApiState.Failed, oac.Status.ApiState);
     }
 
     private OllamaApiClient CreateOllamaApiClient(

--- a/avallama.Tests/Services/Ollama/OllamaProcessManagerTests.cs
+++ b/avallama.Tests/Services/Ollama/OllamaProcessManagerTests.cs
@@ -18,22 +18,23 @@ public class OllamaProcessManagerTests : IClassFixture<TestServicesFixture>
         var opm = new OllamaProcessManager
         {
             StartProcessFunc = _ => new OllamaProcessMock(),
-            GetProcessesFunc = () => []
+            GetProcessesFunc = () => [],
+            GetExecutablePathFunc = () => "/fake/path/to/ollama"
         };
 
         var stateChanged = false;
-        var processState = OllamaProcessLifecycle.Stopped;
+        var processState = OllamaProcessState.Stopped;
 
         opm.StatusChanged += status =>
         {
             if (stateChanged) return;
-            processState = status.ProcessLifecycle;
+            processState = status.ProcessState;
             stateChanged = true;
         };
 
         await opm.StartAsync();
 
-        Assert.Equal(OllamaProcessLifecycle.Starting, processState);
+        Assert.Equal(OllamaProcessState.Starting, processState);
     }
 
     [Fact]
@@ -45,11 +46,11 @@ public class OllamaProcessManagerTests : IClassFixture<TestServicesFixture>
             GetProcessesFunc = () => []
         };
 
-        var processState = OllamaProcessLifecycle.Stopped;
-        opm.StatusChanged += status => processState = status.ProcessLifecycle;
+        var processState = OllamaProcessState.Stopped;
+        opm.StatusChanged += status => processState = status.ProcessState;
         await opm.StartAsync();
 
-        Assert.Equal(OllamaProcessLifecycle.NotInstalled, processState);
+        Assert.Equal(OllamaProcessState.NotInstalled, processState);
     }
 
     [Fact]
@@ -58,13 +59,14 @@ public class OllamaProcessManagerTests : IClassFixture<TestServicesFixture>
         var opm = new OllamaProcessManager
         {
             StartProcessFunc = _ => new OllamaProcessMock(),
-            GetProcessesFunc = () => [ new OllamaProcessMock() ]
+            GetProcessesFunc = () => [ new OllamaProcessMock() ],
+            GetExecutablePathFunc = () => "/fake/path/to/ollama"
         };
 
-        var processState = OllamaProcessLifecycle.Stopped;
-        opm.StatusChanged += status => processState = status.ProcessLifecycle;
+        var processState = OllamaProcessState.Stopped;
+        opm.StatusChanged += status => processState = status.ProcessState;
         await opm.StartAsync();
 
-        Assert.Equal(OllamaProcessLifecycle.Running, processState);
+        Assert.Equal(OllamaProcessState.Running, processState);
     }
 }

--- a/avallama.Tests/ViewModels/HomeViewModelTests.cs
+++ b/avallama.Tests/ViewModels/HomeViewModelTests.cs
@@ -54,13 +54,8 @@ public class HomeViewModelTests(TestServicesFixture fixture) : IClassFixture<Tes
             "model2"
         };
 
-        // raises Running process status so the ViewModel can also listen for API states (it's local connection by default)
         fixture.OllamaMock.Raise(x =>
-            x.ProcessStatusChanged += null, new OllamaProcessStatus(OllamaProcessLifecycle.Running));
-
-        // raises Connected API status so the ViewModel doesn't wait indefinitely for connection
-        fixture.OllamaMock.Raise(x =>
-            x.ApiStatusChanged += null, new OllamaApiStatus(OllamaConnectionState.Connected));
+            x.StatusChanged += null, new OllamaServiceStatus(OllamaServiceState.Ready));
 
         await vm.InitializeAsync();
 
@@ -93,9 +88,8 @@ public class HomeViewModelTests(TestServicesFixture fixture) : IClassFixture<Tes
 
         var vm = CreateViewModel();
 
-        // Raise Connected status so the ViewModel doesn't wait indefinitely for connection
         fixture.OllamaMock.Raise(x =>
-            x.ApiStatusChanged += null, new OllamaApiStatus(OllamaConnectionState.Connected));
+            x.StatusChanged += null, new OllamaServiceStatus(OllamaServiceState.Ready));
 
         await vm.InitializeAsync();
 
@@ -153,9 +147,8 @@ public class HomeViewModelTests(TestServicesFixture fixture) : IClassFixture<Tes
 
         var vm = CreateViewModel();
 
-        // Raise Connected status so the ViewModel doesn't wait indefinitely for connection
         fixture.OllamaMock.Raise(x =>
-            x.ApiStatusChanged += null, new OllamaApiStatus(OllamaConnectionState.Connected));
+            x.StatusChanged += null, new OllamaServiceStatus(OllamaServiceState.Ready));
 
         await vm.InitializeAsync();
 
@@ -234,7 +227,7 @@ public class HomeViewModelTests(TestServicesFixture fixture) : IClassFixture<Tes
         var vm = CreateViewModel();
 
         fixture.OllamaMock.Raise(x =>
-            x.ApiStatusChanged += null, new OllamaApiStatus(OllamaConnectionState.Connected));
+            x.StatusChanged += null, new OllamaServiceStatus(OllamaServiceState.Ready));
 
         await vm.InitializeAsync();
 
@@ -261,7 +254,7 @@ public class HomeViewModelTests(TestServicesFixture fixture) : IClassFixture<Tes
         var vm = CreateViewModel();
 
         fixture.OllamaMock.Raise(x =>
-            x.ApiStatusChanged += null, new OllamaApiStatus(OllamaConnectionState.Connected));
+            x.StatusChanged += null, new OllamaServiceStatus(OllamaServiceState.Ready));
 
         await vm.InitializeAsync();
 

--- a/avallama.Tests/Views/HomeViewTests.cs
+++ b/avallama.Tests/Views/HomeViewTests.cs
@@ -45,13 +45,8 @@ public class HomeViewTests : IClassFixture<TestServicesFixture>
             .Setup(x => x.ReadSetting(It.IsAny<string>()))
             .Returns("");
 
-        // raises Running process status so the ViewModel can also listen for API states (it's local connection by default)
         _fixture.OllamaMock.Raise(x =>
-            x.ProcessStatusChanged += null, new OllamaProcessStatus(OllamaProcessLifecycle.Running));
-
-        // raises Connected status so the ViewModel doesn't wait indefinitely for connection
-        _fixture.OllamaApiClientMock.Raise(x =>
-            x.StatusChanged += null, new OllamaApiStatus(OllamaConnectionState.Connected));
+            x.StatusChanged += null, new OllamaServiceStatus(OllamaServiceState.Ready));
 
         _fixture.OllamaMock
             .Setup(x => x.GetDownloadedModelsAsync())
@@ -101,13 +96,8 @@ public class HomeViewTests : IClassFixture<TestServicesFixture>
 
         var (window, view, viewModel) = CreateAndShowHomeView();
 
-        // raises Running process status so the ViewModel can also listen for API states (it's local connection by default)
         _fixture.OllamaMock.Raise(x =>
-            x.ProcessStatusChanged += null, new OllamaProcessStatus(OllamaProcessLifecycle.Running));
-
-        // Raise Connected status so the ViewModel doesn't wait indefinitely for connection
-        _fixture.OllamaMock.Raise(x =>
-            x.ApiStatusChanged += null, new OllamaApiStatus(OllamaConnectionState.Connected));
+            x.StatusChanged += null, new OllamaServiceStatus(OllamaServiceState.Ready));
 
         await viewModel.InitializeAsync();
 
@@ -163,13 +153,12 @@ public class HomeViewTests : IClassFixture<TestServicesFixture>
         Assert.NotNull(retryPanel);
         Assert.NotNull(retryInfoText);
 
-        // raises Running process status so the ViewModel can also listen for API states (it's local connection by default)
         _fixture.OllamaMock.Raise(x =>
-            x.ProcessStatusChanged += null, new OllamaProcessStatus(OllamaProcessLifecycle.Running));
+            x.StatusChanged += null, new OllamaServiceStatus(OllamaServiceState.Ready));
 
-        // set status to Faulted
         _fixture.OllamaMock.Raise(x =>
-            x.ApiStatusChanged += null, new OllamaApiStatus(OllamaConnectionState.Faulted));
+            x.StatusChanged += null, new OllamaServiceStatus(OllamaServiceState.Failed));
+
         Assert.True(viewModel.IsRetryPanelVisible);
         Assert.True(viewModel.IsRetryButtonVisible);
         Assert.True(retryButton.IsEnabled);
@@ -210,16 +199,16 @@ public class HomeViewTests : IClassFixture<TestServicesFixture>
 
         Assert.NotNull(messageTextBox);
 
-        _fixture.OllamaApiClientMock.Raise(x =>
-            x.StatusChanged += null, new OllamaApiStatus(OllamaConnectionState.Disconnected));
+        _fixture.OllamaMock.Raise(x =>
+            x.StatusChanged += null, new OllamaServiceStatus(OllamaServiceState.Stopped));
         Assert.False(viewModel.IsMessageBoxEnabled);
         Assert.False(messageTextBox.IsEnabled);
 
-        _fixture.OllamaApiClientMock.Raise(x =>
-            x.StatusChanged += null, new OllamaApiStatus(OllamaConnectionState.Connected));
+        _fixture.OllamaMock.Raise(x =>
+            x.StatusChanged += null, new OllamaServiceStatus(OllamaServiceState.Ready));
 
-        _fixture.OllamaApiClientMock.Raise(x =>
-            x.StatusChanged += null, new OllamaApiStatus(OllamaConnectionState.Faulted));
+        _fixture.OllamaMock.Raise(x =>
+            x.StatusChanged += null, new OllamaServiceStatus(OllamaServiceState.Failed));
         Assert.False(viewModel.IsMessageBoxEnabled);
         Assert.False(messageTextBox.IsEnabled);
     }

--- a/avallama/Assets/Localization/Resources.hu.resx
+++ b/avallama/Assets/Localization/Resources.hu.resx
@@ -449,9 +449,6 @@ Licensed under the MIT License. See LICENSE file for details.
     <data name="TEST" xml:space="preserve">
         <value>Lokalizált értékek tesztelése</value>
     </data>
-    <data name="LICENSE" xml:space="preserve">
-        <value>Licensz</value>
-    </data>
     <data name="PARAMETERS" xml:space="preserve">
         <value>Paraméterek</value>
     </data>

--- a/avallama/Assets/Localization/Resources.resx
+++ b/avallama/Assets/Localization/Resources.resx
@@ -457,9 +457,6 @@ Licensed under the MIT License. See LICENSE file for details.
     <data name="TEST" xml:space="preserve">
         <value>Testing localization values</value>
     </data>
-    <data name="LICENSE" xml:space="preserve">
-        <value>License</value>
-    </data>
     <data name="PARAMETERS" xml:space="preserve">
         <value>Parameters</value>
     </data>

--- a/avallama/Constants/States/OllamaApiState.cs
+++ b/avallama/Constants/States/OllamaApiState.cs
@@ -6,7 +6,7 @@ namespace avallama.Constants.States;
 /// <summary>
 /// Defines the possible connection states for the Ollama API client.
 /// </summary>
-public enum OllamaConnectionState
+internal enum OllamaApiState
 {
     /// <summary>
     /// The client is currently attempting to establish a connection.
@@ -31,5 +31,5 @@ public enum OllamaConnectionState
     /// <summary>
     /// The connection failed due to an error (e.g., timeout, unreachable host).
     /// </summary>
-    Faulted
+    Failed
 }

--- a/avallama/Constants/States/OllamaProcessState.cs
+++ b/avallama/Constants/States/OllamaProcessState.cs
@@ -6,7 +6,7 @@ namespace avallama.Constants.States;
 /// <summary>
 /// Defines the lifecycle states of the local Ollama executable process.
 /// </summary>
-public enum OllamaProcessLifecycle
+internal enum OllamaProcessState
 {
     /// <summary>
     /// The process is currently starting up.

--- a/avallama/Constants/States/OllamaServiceState.cs
+++ b/avallama/Constants/States/OllamaServiceState.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Márk Csörgő and Martin Bartos
+// Licensed under the MIT License. See LICENSE file for details.
+
+namespace avallama.Constants.States;
+
+/// <summary>
+/// Represents the unified current state of the Ollama service.
+/// </summary>
+public enum OllamaServiceState
+{
+    /// <summary>
+    /// The Ollama executable is not installed or could not be found on the system.
+    /// </summary>
+    NotInstalled,
+
+    /// <summary>
+    /// The Ollama service is currently stopped or not running.
+    /// </summary>
+    Stopped,
+
+    /// <summary>
+    /// The Ollama service is in the process of starting up or establishing a connection.
+    /// </summary>
+    Starting,
+
+    /// <summary>
+    /// The Ollama service is successfully running, connected, and ready to process requests.
+    /// </summary>
+    Ready,
+
+    /// <summary>
+    /// The Ollama service encountered an error, failed to start, or lost its connection.
+    /// </summary>
+    Failed
+}

--- a/avallama/Models/Ollama/OllamaApiStatus.cs
+++ b/avallama/Models/Ollama/OllamaApiStatus.cs
@@ -8,14 +8,14 @@ namespace avallama.Models.Ollama;
 /// <summary>
 /// Represents the current status of the Ollama API connection, including state and an optional status message.
 /// </summary>
-/// <param name="connectionState">The current state of the API connection.</param>
+/// <param name="apiState">The current state of the API connection.</param>
 /// <param name="message">An optional message providing details about the state (e.g., error messages).</param>
-public class OllamaApiStatus(OllamaConnectionState connectionState, string? message = null)
+internal class OllamaApiStatus(OllamaApiState apiState, string? message = null)
 {
     /// <summary>
     /// Gets or sets the current state of the API connection.
     /// </summary>
-    public OllamaConnectionState ConnectionState { get; set; } = connectionState;
+    public OllamaApiState ApiState { get; set; } = apiState;
 
     /// <summary>
     /// Gets or sets an optional message regarding the status (e.g., error details).

--- a/avallama/Models/Ollama/OllamaProcessStatus.cs
+++ b/avallama/Models/Ollama/OllamaProcessStatus.cs
@@ -8,14 +8,14 @@ namespace avallama.Models.Ollama;
 /// <summary>
 /// Represents the current status of the local Ollama process.
 /// </summary>
-/// <param name="processLifecycle">The current state of the process.</param>
+/// <param name="processState">The current state of the process.</param>
 /// <param name="message">An optional message providing details about the state (e.g. error messages).</param>
-public class OllamaProcessStatus(OllamaProcessLifecycle processLifecycle, string? message = null)
+internal class OllamaProcessStatus(OllamaProcessState processState, string? message = null)
 {
     /// <summary>
     /// Gets or sets the current state of the local Ollama process.
     /// </summary>
-    public OllamaProcessLifecycle ProcessLifecycle { get; set; } = processLifecycle;
+    public OllamaProcessState ProcessState { get; set; } = processState;
 
     /// <summary>
     /// Gets or sets an optional message regarding the process status.

--- a/avallama/Models/Ollama/OllamaServiceStatus.cs
+++ b/avallama/Models/Ollama/OllamaServiceStatus.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Márk Csörgő and Martin Bartos
+// Licensed under the MIT License. See LICENSE file for details.
+
+using avallama.Constants.States;
+
+namespace avallama.Models.Ollama;
+
+/// <summary>
+/// Represents the unified status of Ollama (Process + API).
+/// </summary>
+public class OllamaServiceStatus(OllamaServiceState serviceState, string? message = null)
+{
+    /// <summary>
+    /// Gets or sets the unified current state.
+    /// </summary>
+    public OllamaServiceState ServiceState { get; set; } = serviceState;
+
+    /// <summary>
+    /// Gets or sets an optional message regarding the status (e.g., error details).
+    /// </summary>
+    public string? Message { get; set; } = message;
+}

--- a/avallama/Program.cs
+++ b/avallama/Program.cs
@@ -3,6 +3,9 @@
 
 using Avalonia;
 using System;
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("avallama.Tests")]
 
 namespace avallama;
 

--- a/avallama/Services/ApplicationService.cs
+++ b/avallama/Services/ApplicationService.cs
@@ -114,8 +114,9 @@ public class ApplicationService : IApplicationService
     public void Shutdown()
     {
         if (Application.Current?.ApplicationLifetime is not IClassicDesktopStyleApplicationLifetime desktop) return;
-        desktop.Shutdown();
+        Dispatcher.UIThread.Post(() => { desktop.Shutdown(); });
     }
+
 
     // TODO:
     // This is currently hard to test, what worked for me was to open avallama from the bin/Debug/net10.0 folder

--- a/avallama/Services/Ollama/OllamaApiClient.cs
+++ b/avallama/Services/Ollama/OllamaApiClient.cs
@@ -28,13 +28,13 @@ namespace avallama.Services.Ollama;
 /// <summary>
 /// Delegate for handling changes in the Ollama API connection status.
 /// </summary>
-public delegate void OllamaApiStatusChangedHandler(OllamaApiStatus status);
+internal delegate void OllamaApiStatusChangedHandler(OllamaApiStatus status);
 
 /// <summary>
 /// Defines the contract for interacting with the Ollama API, including connection management,
 /// model retrieval, generation, and deletion.
 /// </summary>
-public interface IOllamaApiClient
+internal interface IOllamaApiClient
 {
     #region Interface
 
@@ -101,7 +101,7 @@ public interface IOllamaApiClient
 /// <summary>
 /// Implementation of the Ollama API client, handling HTTP communication with the Ollama server.
 /// </summary>
-public class OllamaApiClient(
+internal class OllamaApiClient(
     IConfigurationService configurationService,
     INetworkManager networkManager,
     IHttpClientFactory httpClientFactory,
@@ -145,7 +145,7 @@ public class OllamaApiClient(
             field = value;
             StatusChanged?.Invoke(value);
         }
-    } = new(OllamaConnectionState.Disconnected);
+    } = new(OllamaApiState.Disconnected);
 
     #endregion
 
@@ -154,10 +154,10 @@ public class OllamaApiClient(
     /// <inheritdoc/>
     public async Task CheckConnectionAsync()
     {
-        Status = new OllamaApiStatus(OllamaConnectionState.Connecting);
+        Status = new OllamaApiStatus(OllamaApiState.Connecting);
         if (await IsOllamaReachable())
         {
-            Status = new OllamaApiStatus(OllamaConnectionState.Connected);
+            Status = new OllamaApiStatus(OllamaApiState.Connected);
         }
         else
         {
@@ -168,7 +168,7 @@ public class OllamaApiClient(
     /// <inheritdoc/>
     public async Task RetryConnectionAsync()
     {
-        Status = new OllamaApiStatus(OllamaConnectionState.Reconnecting);
+        Status = new OllamaApiStatus(OllamaApiState.Reconnecting);
         _timeProvider.Start();
 
         var loopStartTime = _timeProvider.Elapsed;
@@ -176,7 +176,7 @@ public class OllamaApiClient(
         {
             if (await IsOllamaReachable())
             {
-                Status = new OllamaApiStatus(OllamaConnectionState.Connected);
+                Status = new OllamaApiStatus(OllamaApiState.Connected);
                 return;
             }
 
@@ -263,7 +263,7 @@ public class OllamaApiClient(
 
         if (response.StatusCode == HttpStatusCode.OK)
         {
-            Status = new OllamaApiStatus(OllamaConnectionState.Connected);
+            Status = new OllamaApiStatus(OllamaApiState.Connected);
         }
         else
         {
@@ -344,7 +344,7 @@ public class OllamaApiClient(
             response = await _heavyHttpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct);
             if (response.StatusCode == HttpStatusCode.OK)
             {
-                Status = new OllamaApiStatus(OllamaConnectionState.Connected);
+                Status = new OllamaApiStatus(OllamaApiState.Connected);
             }
         }
         catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
@@ -431,12 +431,12 @@ public class OllamaApiClient(
     {
         if (IsConnectionRemote(configurationService.ReadSetting(ConfigurationKey.ApiHost)))
         {
-            Status = new OllamaApiStatus(OllamaConnectionState.Faulted,
+            Status = new OllamaApiStatus(OllamaApiState.Failed,
                 LocalizationService.GetString("OLLAMA_REMOTE_UNREACHABLE"));
         }
         else
         {
-            Status = new OllamaApiStatus(OllamaConnectionState.Faulted,
+            Status = new OllamaApiStatus(OllamaApiState.Failed,
                 LocalizationService.GetString("OLLAMA_LOCAL_UNREACHABLE"));
         }
     }

--- a/avallama/Services/Ollama/OllamaProcessManager.cs
+++ b/avallama/Services/Ollama/OllamaProcessManager.cs
@@ -22,12 +22,12 @@ namespace avallama.Services.Ollama;
 /// <summary>
 /// Delegate for handling changes in the Ollama process status.
 /// </summary>
-public delegate void OllamaProcessStatusChangedHandler(OllamaProcessStatus status);
+internal delegate void OllamaProcessStatusChangedHandler(OllamaProcessStatus status);
 
 /// <summary>
 /// Defines a contract for managing the lifecycle of the local Ollama process.
 /// </summary>
-public interface IOllamaProcessManager
+internal interface IOllamaProcessManager
 {
     #region Interface
 
@@ -58,7 +58,7 @@ public interface IOllamaProcessManager
 /// Manages the lifecycle of the local Ollama server process, including starting, stopping, and monitoring its status.
 /// Handles both processes started by the application and existing instances.
 /// </summary>
-public class OllamaProcessManager : IOllamaProcessManager, IDisposable
+internal class OllamaProcessManager : IOllamaProcessManager, IDisposable
 {
     #region Dependencies & Fields
 
@@ -75,6 +75,11 @@ public class OllamaProcessManager : IOllamaProcessManager, IDisposable
     /// Function to retrieve running processes. Can be replaced for testing purposes.
     /// </summary>
     public Func<IEnumerable<IOllamaProcess>> GetProcessesFunc { get; init; }
+
+    /// <summary>
+    /// Function to retrieve the Ollama executable path. Can be replaced for testing purposes.
+    /// </summary>
+    public Func<string> GetExecutablePathFunc { get; init; }
 
     /// <summary>
     /// Function to check if Ollama is running as a systemd service (Linux only). Can be replaced for testing purposes.
@@ -98,6 +103,7 @@ public class OllamaProcessManager : IOllamaProcessManager, IDisposable
         // Initialize default implementations if not provided (e.g., by tests)
         GetProcessesFunc ??= () => Process.GetProcessesByName("ollama").Select(p => new OllamaProcess(p));
         CheckSystemdStatusFunc ??= IsOllamaRunningAsSystemdService;
+        GetExecutablePathFunc ??= GetOllamaExecutablePath;
     }
 
     #endregion
@@ -115,7 +121,7 @@ public class OllamaProcessManager : IOllamaProcessManager, IDisposable
             field = value;
             StatusChanged?.Invoke(value);
         }
-    } = new(OllamaProcessLifecycle.Stopped);
+    } = new(OllamaProcessState.Stopped);
 
     #endregion
 
@@ -127,9 +133,15 @@ public class OllamaProcessManager : IOllamaProcessManager, IDisposable
 
         try
         {
-            Status = new OllamaProcessStatus(OllamaProcessLifecycle.Starting);
+            Status = new OllamaProcessStatus(OllamaProcessState.Starting);
 
-            OllamaPath = GetOllamaExecutablePath();
+            OllamaPath = GetExecutablePathFunc();
+
+            if (string.IsNullOrEmpty(OllamaPath))
+            {
+                Status = new OllamaProcessStatus(OllamaProcessState.NotInstalled);
+                return;
+            }
 
             // check for existing instances (real server processes).
             // we get all processes named "ollama" and ensure they don't have a window handle
@@ -150,7 +162,7 @@ public class OllamaProcessManager : IOllamaProcessManager, IDisposable
                     _ollamaProcess.Exited += OnOllamaProcessExited;
                 }
 
-                Status = new OllamaProcessStatus(OllamaProcessLifecycle.Running,
+                Status = new OllamaProcessStatus(OllamaProcessState.Running,
                     LocalizationService.GetString("OLLAMA_ALREADY_RUNNING"));
                 return;
             }
@@ -158,7 +170,7 @@ public class OllamaProcessManager : IOllamaProcessManager, IDisposable
             {
                 _isProcessStartedByAvallama = false;
                 // multiple instances found, report failure rather than attempting to kill them
-                Status = new OllamaProcessStatus(OllamaProcessLifecycle.Failed,
+                Status = new OllamaProcessStatus(OllamaProcessState.Failed,
                     LocalizationService.GetString("MULTIPLE_INSTANCES_ERROR"));
                 return;
             }
@@ -185,21 +197,21 @@ public class OllamaProcessManager : IOllamaProcessManager, IDisposable
                     // Only set newly started process if everything ran correctly without exceptions
                     _ollamaProcess = tempProcess;
                     _isProcessStartedByAvallama = true;
-                    Status = new OllamaProcessStatus(OllamaProcessLifecycle.Running);
+                    Status = new OllamaProcessStatus(OllamaProcessState.Running);
                     return;
                 }
 
-                Status = new OllamaProcessStatus(OllamaProcessLifecycle.NotInstalled);
+                Status = new OllamaProcessStatus(OllamaProcessState.NotInstalled);
             }
             catch (Win32Exception)
             {
-                Status = new OllamaProcessStatus(OllamaProcessLifecycle.NotInstalled);
+                Status = new OllamaProcessStatus(OllamaProcessState.NotInstalled);
                 try { tempProcess?.Kill(); } catch { /* ignore */ }
                 tempProcess?.Dispose();
             }
             catch (Exception ex)
             {
-                Status = new OllamaProcessStatus(OllamaProcessLifecycle.Failed,
+                Status = new OllamaProcessStatus(OllamaProcessState.Failed,
                     string.Format(LocalizationService.GetString("OLLAMA_FAILED"), ex.Message));
                 try { tempProcess?.Kill(); } catch { /* ignore */ }
                 tempProcess?.Dispose();
@@ -247,7 +259,7 @@ public class OllamaProcessManager : IOllamaProcessManager, IDisposable
         }
 
         _ollamaProcess = null;
-        Status = new OllamaProcessStatus(OllamaProcessLifecycle.Stopped);
+        Status = new OllamaProcessStatus(OllamaProcessState.Stopped);
     }
 
     #endregion
@@ -257,10 +269,10 @@ public class OllamaProcessManager : IOllamaProcessManager, IDisposable
     private void OnOllamaProcessExited(object? sender, EventArgs e)
     {
         // ignore process exit if the user stopped the process intentionally via the app
-        if (Status.ProcessLifecycle == OllamaProcessLifecycle.Stopped) return;
+        if (Status.ProcessState == OllamaProcessState.Stopped) return;
 
         string? message = null;
-        var newState = OllamaProcessLifecycle.Stopped;
+        var newState = OllamaProcessState.Stopped;
 
         if (sender is IOllamaProcess process)
         {
@@ -268,14 +280,14 @@ public class OllamaProcessManager : IOllamaProcessManager, IDisposable
             {
                 if (process.ExitCode != 0)
                 {
-                    newState = OllamaProcessLifecycle.Failed;
+                    newState = OllamaProcessState.Failed;
                     message = LocalizationService.GetString("OLLAMA_STOPPED_UNEXPECTEDLY")
                               + $" ({LocalizationService.GetString("EXIT_CODE")}: {process.ExitCode})";
                 }
             }
             catch (Exception)
             {
-                newState = OllamaProcessLifecycle.Failed;
+                newState = OllamaProcessState.Failed;
                 message = LocalizationService.GetString("OLLAMA_STOPPED_UNEXPECTEDLY");
             }
         }

--- a/avallama/Services/Ollama/OllamaService.cs
+++ b/avallama/Services/Ollama/OllamaService.cs
@@ -5,11 +5,16 @@ using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
+using avallama.Constants.Keys;
+using avallama.Constants.States;
 using avallama.Models;
 using avallama.Models.Dtos;
 using avallama.Models.Ollama;
+using avallama.Services.Persistence;
 
 namespace avallama.Services.Ollama;
+
+public delegate void OllamaServiceStatusChangedHandler(OllamaServiceStatus serviceStatus);
 
 /// <summary>
 /// Defines a high-level service for interacting with the Ollama ecosystem.
@@ -20,24 +25,14 @@ public interface IOllamaService
     #region Interface
 
     /// <summary>
-    /// Gets the current status of the local Ollama process.
+    /// Gets the unified current status of Ollama.
     /// </summary>
-    OllamaProcessStatus CurrentProcessStatus { get; }
+    OllamaServiceStatus CurrentServiceStatus { get; }
 
     /// <summary>
-    /// Gets the current status of the Ollama API connection.
+    /// Event raised when the unified status of Ollama changes.
     /// </summary>
-    OllamaApiStatus CurrentApiStatus { get; }
-
-    /// <summary>
-    /// Event raised when the status of the local Ollama process changes.
-    /// </summary>
-    event OllamaProcessStatusChangedHandler? ProcessStatusChanged;
-
-    /// <summary>
-    /// Event raised when the status of the Ollama API connection changes.
-    /// </summary>
-    event OllamaApiStatusChangedHandler? ApiStatusChanged;
+    event OllamaServiceStatusChangedHandler? StatusChanged;
 
     /// <summary>
     /// Starts the local Ollama process asynchronously.
@@ -114,54 +109,75 @@ public interface IOllamaService
 /// <summary>
 /// Implementation of the IOllamaService facade, orchestrating process management, API calls, and scraping.
 /// </summary>
-public class OllamaService(
-    IOllamaProcessManager processManager,
-    IOllamaApiClient apiClient,
-    IOllamaScraper ollamaScraper)
-    : IOllamaService
+internal class OllamaService : IOllamaService
 {
+    #region Fields
+
+    private IOllamaProcessManager _processManager;
+    private IOllamaApiClient _apiClient;
+    private IOllamaScraper _scraper;
+    private IConfigurationService _configurationService;
+
     private OllamaScraperResult? _currentScrapeSession;
+
+    #endregion
+
+    #region Constructor
+
+    public OllamaService(
+        IOllamaProcessManager processManager,
+        IOllamaApiClient apiClient,
+        IOllamaScraper scraper,
+        IConfigurationService configurationService)
+    {
+        _processManager = processManager;
+        _apiClient = apiClient;
+        _scraper = scraper;
+        _configurationService = configurationService;
+
+        _processManager.StatusChanged += _ => EvaluateServiceStatus();
+        _apiClient.StatusChanged += _ => EvaluateServiceStatus();
+    }
+
+    #endregion
 
     #region Events & Status
 
-    public event OllamaProcessStatusChangedHandler? ProcessStatusChanged
+    public event OllamaServiceStatusChangedHandler? StatusChanged;
+
+    public OllamaServiceStatus CurrentServiceStatus
     {
-        add => processManager.StatusChanged += value;
-        remove => processManager.StatusChanged -= value;
-    }
-
-    public event OllamaApiStatusChangedHandler? ApiStatusChanged
-    {
-        add => apiClient.StatusChanged += value;
-        remove => apiClient.StatusChanged -= value;
-    }
-
-    public OllamaApiStatus CurrentApiStatus => apiClient.Status;
-
-    public OllamaProcessStatus CurrentProcessStatus => processManager.Status;
+        get;
+        private set
+        {
+            if (field.ServiceState == value.ServiceState && field.Message == value.Message) return;
+            field = value;
+            StatusChanged?.Invoke(value);
+        }
+    } = new(OllamaServiceState.Stopped);
 
     #endregion
 
     #region Process Management
 
-    public async Task StartOllamaProcessAsync() => await processManager.StartAsync();
-    public async Task StopOllamaProcessAsync() => await processManager.StopAsync();
+    public async Task StartOllamaProcessAsync() => await _processManager.StartAsync();
+    public async Task StopOllamaProcessAsync() => await _processManager.StopAsync();
 
     #endregion
 
     #region API
 
-    public async Task CheckOllamaApiConnectionAsync() => await apiClient.CheckConnectionAsync();
-    public async Task RetryOllamaApiConnectionAsync() => await apiClient.RetryConnectionAsync();
-    public async Task EnrichModelAsync(OllamaModel model) => await apiClient.EnrichModelAsync(model);
-    public async Task<IList<OllamaModel>> GetDownloadedModelsAsync() => await apiClient.GetDownloadedModelsAsync();
-    public async Task<bool> DeleteModelAsync(string modelName) => await apiClient.DeleteModelAsync(modelName);
+    public async Task CheckOllamaApiConnectionAsync() => await _apiClient.CheckConnectionAsync();
+    public async Task RetryOllamaApiConnectionAsync() => await _apiClient.RetryConnectionAsync();
+    public async Task EnrichModelAsync(OllamaModel model) => await _apiClient.EnrichModelAsync(model);
+    public async Task<IList<OllamaModel>> GetDownloadedModelsAsync() => await _apiClient.GetDownloadedModelsAsync();
+    public async Task<bool> DeleteModelAsync(string modelName) => await _apiClient.DeleteModelAsync(modelName);
 
     public async IAsyncEnumerable<DownloadResponse> DownloadModelAsync(
         string modelName,
         [EnumeratorCancellation] CancellationToken ct = default)
     {
-        await foreach (var response in apiClient.PullModelAsync(modelName, ct))
+        await foreach (var response in _apiClient.PullModelAsync(modelName, ct))
         {
             yield return response;
         }
@@ -172,7 +188,7 @@ public class OllamaService(
         string modelName,
         [EnumeratorCancellation] CancellationToken ct = default)
     {
-        await foreach (var response in apiClient.GenerateMessageAsync(messageHistory, modelName, ct))
+        await foreach (var response in _apiClient.GenerateMessageAsync(messageHistory, modelName, ct))
         {
             yield return response;
         }
@@ -196,13 +212,98 @@ public class OllamaService(
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         _currentScrapeSession = null;
-        var result = await ollamaScraper.GetAllOllamaModelsAsync(cancellationToken);
+        var result = await _scraper.GetAllOllamaModelsAsync(cancellationToken);
         _currentScrapeSession = result;
 
         await foreach (var model in result.Models.WithCancellation(cancellationToken))
         {
             yield return model;
         }
+    }
+
+    #endregion
+
+    #region Private Methods
+
+    /// <summary>
+    /// Aggregates the internal Process and API statuses into a single public state.
+    /// </summary>
+    private void EvaluateServiceStatus()
+    {
+        var isRemote = OllamaApiClient.IsConnectionRemote(_configurationService.ReadSetting(ConfigurationKey.ApiHost));
+
+        OllamaServiceState newServiceState;
+        string? message = null;
+
+        if (isRemote)
+        {
+            // if it's remote we only check for the API state
+            switch (_apiClient.Status.ApiState)
+            {
+                case OllamaApiState.Connecting:
+                case OllamaApiState.Reconnecting:
+                    newServiceState = OllamaServiceState.Starting;
+                    break;
+
+                case OllamaApiState.Connected:
+                    newServiceState = OllamaServiceState.Ready;
+                    break;
+
+                case OllamaApiState.Failed:
+                    newServiceState = OllamaServiceState.Failed;
+                    message = _apiClient.Status.Message;
+                    break;
+
+                case OllamaApiState.Disconnected:
+                default:
+                    newServiceState = OllamaServiceState.Stopped;
+                    break;
+            }
+        }
+        else
+        {
+            // if it's local we check for both the Process and API states
+            var procState = _processManager.Status.ProcessState;
+            var apiState = _apiClient.Status.ApiState;
+
+            switch (procState)
+            {
+                case OllamaProcessState.NotInstalled:
+                    newServiceState = OllamaServiceState.NotInstalled;
+                    message = _processManager.Status.Message;
+                    break;
+
+                case OllamaProcessState.Failed:
+                    newServiceState = OllamaServiceState.Failed;
+                    message = _processManager.Status.Message;
+                    break;
+
+                case OllamaProcessState.Stopped:
+                    newServiceState = OllamaServiceState.Stopped;
+                    break;
+
+                case OllamaProcessState.Starting:
+                case OllamaProcessState.Running when apiState is OllamaApiState.Connecting or OllamaApiState.Reconnecting:
+                    // if the process starts, or the process is already running but the client is still connecting to API
+                    newServiceState = OllamaServiceState.Starting;
+                    break;
+
+                case OllamaProcessState.Running when apiState == OllamaApiState.Connected:
+                    newServiceState = OllamaServiceState.Ready;
+                    break;
+
+                case OllamaProcessState.Running when apiState == OllamaApiState.Failed:
+                    newServiceState = OllamaServiceState.Failed;
+                    message = _apiClient.Status.Message;
+                    break;
+
+                default:
+                    newServiceState = OllamaServiceState.Stopped;
+                    break;
+            }
+        }
+
+        CurrentServiceStatus = new OllamaServiceStatus(newServiceState, message);
     }
 
     #endregion

--- a/avallama/Utilities/DiskManager.cs
+++ b/avallama/Utilities/DiskManager.cs
@@ -37,7 +37,7 @@ public static class DiskManager
                 return driveInfo.AvailableFreeSpace >= requiredBytes + reserveBytes;
             }
         }
-        catch (IOException ex)
+        catch (IOException)
         {
             // TODO: InterruptService
         }
@@ -57,7 +57,7 @@ public static class DiskManager
                 return driveInfo.AvailableFreeSpace;
             }
         }
-        catch (IOException ex)
+        catch (IOException)
         {
             // TODO: InterruptService
         }

--- a/avallama/ViewModels/HomeViewModel.cs
+++ b/avallama/ViewModels/HomeViewModel.cs
@@ -18,12 +18,13 @@ using avallama.Services;
 using avallama.Services.Ollama;
 using avallama.Services.Persistence;
 using avallama.Utilities;
-using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
 
 namespace avallama.ViewModels;
+
+// TODO: extract conversation logic into ConversationViewModel as the current implementation is not optimal
 
 /// <summary>
 /// ViewModel for the Home page, managing chat conversations, model selection,
@@ -53,8 +54,7 @@ public partial class HomeViewModel : PageViewModel
     private ObservableStack<Conversation>? _conversations;
     private ObservableCollection<string> _availableModels;
 
-    private TaskCompletionSource<bool> _connectedToOllamaApi = new();
-    private bool _checkForApiStatus;
+    private TaskCompletionSource<bool> _isOllamaReady = new();
 
     #endregion
 
@@ -179,8 +179,7 @@ public partial class HomeViewModel : PageViewModel
 
         LoadSettings();
 
-        _ollamaService.ProcessStatusChanged += OllamaProcessStatusChanged;
-        _ollamaService.ApiStatusChanged += OllamaApiStatusChanged;
+        _ollamaService.StatusChanged += OllamaServiceStatusChanged;
     }
 
     #endregion
@@ -353,34 +352,8 @@ public partial class HomeViewModel : PageViewModel
         }
         else
         {
-            switch (_ollamaService.CurrentProcessStatus.ProcessLifecycle)
-            {
-                case OllamaProcessLifecycle.NotInstalled:
-                    // TODO: change this to not shutdown and add new localization key
-                    // localized text should explain that ollama is not installed and to use the app it needs a remote connection
-
-                    _dialogService.ShowActionDialog(
-                        title: LocalizationService.GetString("OLLAMA_NOT_INSTALLED"),
-                        actionButtonText: LocalizationService.GetString("DOWNLOAD"),
-                        action: () =>
-                        {
-                            RedirectToOllamaDownload();
-                            // Message to AppService to shut down the app
-                            _messenger.Send(new ApplicationMessage.Shutdown());
-                        },
-                        closeAction: () => { _messenger.Send(new ApplicationMessage.Shutdown()); },
-                        description: LocalizationService.GetString("OLLAMA_NOT_INSTALLED_DESC"),
-                        actionButtonOnly: false
-                    );
-                    break;
-                case OllamaProcessLifecycle.Failed or OllamaProcessLifecycle.Stopped:
-                    await _ollamaService.StartOllamaProcessAsync();
-                    await _ollamaService.RetryOllamaApiConnectionAsync();
-                    break;
-                case OllamaProcessLifecycle.Running:
-                    await _ollamaService.RetryOllamaApiConnectionAsync();
-                    break;
-            }
+            await _ollamaService.StartOllamaProcessAsync();
+            await _ollamaService.RetryOllamaApiConnectionAsync();
         }
     }
 
@@ -483,16 +456,16 @@ public partial class HomeViewModel : PageViewModel
     private async Task InitializeModels()
     {
         // cancel the previous connection waiting Task and initialize a new one if it's completed/API was connected
-        if (_connectedToOllamaApi.Task.IsCompleted ||
-            _ollamaService.CurrentApiStatus.ConnectionState == OllamaConnectionState.Connected)
+        if (_isOllamaReady.Task.IsCompleted ||
+            _ollamaService.CurrentServiceStatus.ServiceState == OllamaServiceState.Ready)
         {
-            _connectedToOllamaApi.TrySetCanceled();
-            _connectedToOllamaApi = new TaskCompletionSource<bool>();
+            _isOllamaReady.TrySetCanceled();
+            _isOllamaReady = new TaskCompletionSource<bool>();
         }
         else
         {
             // waits for the Ollama API connection
-            await _connectedToOllamaApi.Task;
+            await _isOllamaReady.Task;
         }
 
         // caches the previously selected model name
@@ -638,20 +611,19 @@ public partial class HomeViewModel : PageViewModel
     }
 
     /// <summary>
-    /// Handles changes when Ollama API status changes and updates UI elements accordingly.
+    /// Handles changes in the unified Ollama status and updates UI elements accordingly.
     /// </summary>
-    private void OllamaApiStatusChanged(OllamaApiStatus status)
+    private void OllamaServiceStatusChanged(OllamaServiceStatus status)
     {
-        if (!_checkForApiStatus) return;
-        switch (status.ConnectionState)
+        switch (status.ServiceState)
         {
-            case OllamaConnectionState.Reconnecting or OllamaConnectionState.Connecting:
-                SetViewState(true, false, false,
-                    false, RetryInfoText = LocalizationService.GetString("CONNECTING"));
+            case OllamaServiceState.Starting:
+                SetViewState(true, false, false, false,
+                    LocalizationService.GetString("CONNECTING"));
                 break;
 
-            case OllamaConnectionState.Connected:
-                _connectedToOllamaApi.TrySetResult(true);
+            case OllamaServiceState.Ready:
+                _isOllamaReady.TrySetResult(true);
                 var apiHost = _configurationService.ReadSetting(ConfigurationKey.ApiHost);
                 var apiPort = _configurationService.ReadSetting(ConfigurationKey.ApiPort);
 
@@ -666,74 +638,33 @@ public partial class HomeViewModel : PageViewModel
                     IsRemoteConnectionTextVisible = false;
                 }
 
-                SetViewState(false, false,
-                    !string.IsNullOrEmpty(SelectedModelName), true);
+                SetViewState(false, false, !string.IsNullOrEmpty(SelectedModelName), true);
                 break;
 
-            case OllamaConnectionState.Faulted or OllamaConnectionState.Disconnected:
+            case OllamaServiceState.Failed:
+            case OllamaServiceState.Stopped:
                 ReplaceGeneratedMessageToFailed();
                 IsRemoteConnectionTextVisible = false;
                 SetViewState(true, true, false, false,
                     status.Message ?? LocalizationService.GetString("OLLAMA_CONNECTION_ERROR"));
                 break;
-        }
-    }
 
-    /// <summary>
-    /// Handles changes when Ollama process status changes and updates UI elements accordingly.
-    /// </summary>
-    private void OllamaProcessStatusChanged(OllamaProcessStatus status)
-    {
-        switch (status.ProcessLifecycle)
-        {
-            case OllamaProcessLifecycle.Running:
-                _checkForApiStatus = true;
-                break;
-
-            case OllamaProcessLifecycle.NotInstalled:
-                if (OllamaApiClient.IsConnectionRemote(_configurationService.ReadSetting(ConfigurationKey.ApiHost)))
-                {
-                    _checkForApiStatus = true;
-                    return;
-                }
+            case OllamaServiceState.NotInstalled:
+                // TODO:
+                // change this later to not shutdown
+                // so the user still can use the app (browse conversations, fetch model metadata from Ollama website etc.)
                 _dialogService.ShowActionDialog(
                     title: LocalizationService.GetString("OLLAMA_NOT_INSTALLED"),
                     actionButtonText: LocalizationService.GetString("DOWNLOAD"),
                     action: () =>
                     {
                         RedirectToOllamaDownload();
-                        // Message to AppService to shut down the app
                         _messenger.Send(new ApplicationMessage.Shutdown());
                     },
                     closeAction: () => { _messenger.Send(new ApplicationMessage.Shutdown()); },
                     description: LocalizationService.GetString("OLLAMA_NOT_INSTALLED_DESC"),
-                    false
+                    actionButtonOnly: false
                 );
-                break;
-
-            case OllamaProcessLifecycle.Starting:
-                if (OllamaApiClient.IsConnectionRemote(_configurationService.ReadSetting(ConfigurationKey.ApiHost)))
-                {
-                    _checkForApiStatus = true;
-                    return;
-                }
-
-                _checkForApiStatus = false;
-                SetViewState(true, false, false,
-                    false, RetryInfoText = LocalizationService.GetString("CONNECTING"));
-                break;
-
-            case OllamaProcessLifecycle.Failed or OllamaProcessLifecycle.Stopped:
-                if (OllamaApiClient.IsConnectionRemote(_configurationService.ReadSetting(ConfigurationKey.ApiHost)))
-                {
-                    _checkForApiStatus = true;
-                    return;
-                }
-
-                _checkForApiStatus = false;
-                ReplaceGeneratedMessageToFailed();
-                SetViewState(true, true, false, false,
-                    status.Message ?? LocalizationService.GetString("OLLAMA_CONNECTION_ERROR"));
                 break;
         }
     }

--- a/avallama/ViewModels/ModelManagerViewModel.cs
+++ b/avallama/ViewModels/ModelManagerViewModel.cs
@@ -25,6 +25,8 @@ using CommunityToolkit.Mvvm.Messaging;
 
 namespace avallama.ViewModels;
 
+// TODO: handle OllamaService status changes and update UI accordingly
+
 public partial class ModelManagerViewModel : PageViewModel
 {
     private readonly IDialogService _dialogService;
@@ -341,9 +343,4 @@ public partial class ModelManagerViewModel : PageViewModel
     {
         _dialogService.ShowInfoDialog(LocalizationService.GetString("MODEL_MANAGER_GUIDE"));
     }
-
-    // TODO:
-    // add missing API & Process status handling, possibly with IMessenger, make it generalized
-    // so ViewModels doesn't have to subscribe to them one by one
-    // this is necessary so Model Manager can also notify the user if the process or API fails/stops unexpectedly
 }

--- a/avallama/ViewModels/SettingsViewModel.cs
+++ b/avallama/ViewModels/SettingsViewModel.cs
@@ -40,6 +40,7 @@ public partial class SettingsViewModel : PageViewModel
             field = value;
             if (value)
             {
+                /*
                 // asynchronously show restart dialog on the UI thread
                 Dispatcher.UIThread.InvokeAsync(async () =>
                 {
@@ -56,6 +57,10 @@ public partial class SettingsViewModel : PageViewModel
                         _messenger.Send(new ApplicationMessage.Restart());
                     }
                 });
+                */
+
+                // TODO: replace this with the confirmation dialog if app restart is fixed
+                _dialogService.ShowInfoDialog(LocalizationService.GetString("RESTART_NEEDED_DIALOG_TITLE"));
             }
 
             OnPropertyChanged();

--- a/avallama/Views/SettingsView.axaml
+++ b/avallama/Views/SettingsView.axaml
@@ -9,7 +9,6 @@ Licensed under the MIT License. See LICENSE file for details.
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:avallama.ViewModels"
              xmlns:services="clr-namespace:avallama.Services"
-             xmlns:avallama="clr-namespace:avallama"
              mc:Ignorable="d"
              d:DesignHeight="600" d:DesignWidth="800"
              x:Class="avallama.Views.SettingsView"
@@ -151,7 +150,7 @@ Licensed under the MIT License. See LICENSE file for details.
                                 Command="{Binding Path=((vm:MainViewModel)DataContext).StartScraper, RelativeSource={RelativeSource AncestorType=Window}}" />
                         <TextBlock Text="{Binding LastModelUpdate}"
                                    FontSize="14"
-                                   VerticalAlignment="Center"/>
+                                   VerticalAlignment="Center" />
                     </StackPanel>
                 </Grid>
 
@@ -176,7 +175,7 @@ Licensed under the MIT License. See LICENSE file for details.
                                 <Run Text="Ollama API, Avalonia framework" />
                             </TextBlock>
                             <TextBlock Margin="0,16,0,0">
-                                <Run Text="{services:LocalizationService Key='LICENSE'}" />
+                                <Run Text="{services:LocalizationService Key='LICENSE_DETAILS'}" />
                             </TextBlock>
                             <StackPanel Orientation="Horizontal">
                                 <Button Content="{services:LocalizationService Key='GITHUB_BUTTON'}"
@@ -190,7 +189,7 @@ Licensed under the MIT License. See LICENSE file for details.
                             <Separator Margin="0,16,0,0" Opacity="0.3" />
                             <TextBlock HorizontalAlignment="Center" Margin="0,16,0,0" VerticalAlignment="Bottom">
                                 <Run Text="Copyright" FontWeight="Bold" />
-                                <Run Text="© 2025 Márk Csörgő and Martin Bartos" />
+                                <Run Text="© 2026 Márk Csörgő and Martin Bartos" />
                             </TextBlock>
                             <TextBlock Text="{services:LocalizationService Key='FROM_TEAM'}"
                                        HorizontalAlignment="Center"


### PR DESCRIPTION
### Changes
- Refactored process and API status handling in `OllamaService`. So it exposes a single, unified status to the UI layer, simplifying ViewModel logic.
- Renamed state and status types to be more consistent and avoid miscomprehension
- Fixed an issue where requesting an application shutdown via `IMessenger` caused a crash/exception
- Fixed an issue where an empty path for the Ollama executable would throw a generic exception instead of setting the `NotInstalled` status.
- Temporarily replaced the restart dialog in the settings with an info dialog to prevent issues
- Updated the copyright and license text in settings