### PR TITLE
Update dotnet dependencies + bump ver

### DIFF
--- a/avallama.Tests/avallama.Tests.csproj
+++ b/avallama.Tests/avallama.Tests.csproj
@@ -13,7 +13,7 @@ Licensed under the MIT License. See LICENSE file for details.
     <!-- Versions -->
     <PropertyGroup>
         <AvaloniaVersion>11.3.16</AvaloniaVersion>
-        <DotNetLibVersion>10.0.0</DotNetLibVersion>
+        <DotNetLibVersion>10.0.9</DotNetLibVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/avallama/App.axaml.cs
+++ b/avallama/App.axaml.cs
@@ -27,7 +27,7 @@ public partial class App : Application
     private DialogService? _dialogService;
     private DatabaseInitService? _databaseInitService;
     public static SqliteConnection SharedDbConnection { get; private set; } = null!;
-    public static readonly Version Version = new (0, 3, 2);
+    public static readonly Version Version = new (0, 3, 3);
 
     public override void Initialize()
     {

--- a/avallama/avallama.csproj
+++ b/avallama/avallama.csproj
@@ -31,7 +31,7 @@ Licensed under the MIT License. See LICENSE file for details.
     <!-- Versions -->
     <PropertyGroup>
         <AvaloniaVersion>11.3.16</AvaloniaVersion>
-        <DotNetLibVersion>10.0.0</DotNetLibVersion>
+        <DotNetLibVersion>10.0.9</DotNetLibVersion>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
To mitigate CVE-2026-45591 (https://github.com/4foureyes/avallama/security/dependabot/2)

I suggest cutting a release from this branch, then cherry picking back to main so we don't include WIP features in the release