### PR TITLE
Fix last used model in conversation list

### DIFF
--- a/avallama.Tests/Services/Persistence/ConversationsServiceTests.cs
+++ b/avallama.Tests/Services/Persistence/ConversationsServiceTests.cs
@@ -166,6 +166,20 @@ public class ConversationServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task GetConversations_WithAssistantMessage_ShouldPopulateModelField()
+    {
+        var id = await _conversationService.CreateConversation(
+            new Conversation(Guid.Empty, "Model Test", new List<Message>()));
+        const string model = "test";
+        await _conversationService.InsertMessage(id, new GeneratedMessage("test", 0.0), model, 0.0);
+
+        var conversations = await _conversationService.GetConversations();
+
+        Assert.Equal(id, conversations.First().ConversationId);
+        Assert.Equal(model, conversations.First().Model);
+    }
+
+    [Fact]
     public async Task CreateConversation_WithSpecialCharactersInTitle_ShouldSucceed()
     {
         const string title = "Test's \"Conversation\" with <special> & chars!";

--- a/avallama.Tests/avallama.Tests.csproj
+++ b/avallama.Tests/avallama.Tests.csproj
@@ -23,7 +23,7 @@ Licensed under the MIT License. See LICENSE file for details.
         <PackageReference Include="Avalonia.Themes.Fluent" Version="$(AvaloniaVersion)" />
 
         <!-- .NET packages -->
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
 
         <!-- third party and other packages -->
         <PackageReference Include="Moq" Version="4.20.72" />
@@ -32,7 +32,7 @@ Licensed under the MIT License. See LICENSE file for details.
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.4">
+        <PackageReference Include="coverlet.collector" Version="10.0.1">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/avallama/Services/Persistence/ConversationService.cs
+++ b/avallama/Services/Persistence/ConversationService.cs
@@ -220,8 +220,7 @@ public class ConversationService : IConversationService, IDisposable
             foreach (var conv in conversations)
             {
                 conv.Model =
-                    lastModels.GetValueOrDefault(conv.ConversationId,
-                        "llama3.2:2b"); // this default could be set in settings?
+                    lastModels.GetValueOrDefault(conv.ConversationId, "");
             }
         }
 
@@ -241,28 +240,34 @@ public class ConversationService : IConversationService, IDisposable
         var idsParam = string.Join(",", enumerable.Select((_, i) => $"@id{i}"));
         await using var cmd = _connection.CreateCommand();
         cmd.CommandText = $"""
-                               SELECT conversation_id, model_name
-                               FROM (
-                                   SELECT conversation_id, model_name,
-                                          ROW_NUMBER() OVER (PARTITION BY conversation_id ORDER BY timestamp DESC) AS rn
-                                   FROM messages
-                                   WHERE conversation_id IN ({idsParam})
-                               )
-                               WHERE rn = 1
-                           """;
-
+                                SELECT conversation_id, model_name
+                                   FROM (
+                                       SELECT
+                                           conversation_id,
+                                           model_name,
+                                           ROW_NUMBER() OVER (
+                                               PARTITION BY conversation_id
+                                               ORDER BY timestamp DESC, id DESC
+                                           ) AS rn
+                                       FROM messages
+                                       WHERE conversation_id IN ({idsParam})
+                                         AND role = 'assistant'
+                                         AND model_name IS NOT NULL
+                                   )
+                                   WHERE rn = 1;
+                            """;
 
         var index = 0;
         foreach (var id in enumerable)
-            cmd.Parameters.AddWithValue($"@id{index++}", id.ToString());
+            cmd.Parameters.AddWithValue($"@id{index++}", id.ToString().ToUpper());
 
         try
         {
             await using var reader = await cmd.ExecuteReaderAsync();
             while (await reader.ReadAsync())
             {
-                var convId = Guid.Parse((string)reader["conversation_id"]);
-                var model = reader.IsDBNull(1) ? "llama3.2:2b" : (string)reader["model_name"];
+                var convId = Guid.Parse(reader.GetString(0));
+                var model = reader.GetString(1);
                 lastModels[convId] = model;
             }
         }


### PR DESCRIPTION
Fixes https://github.com/4foureyes/avallamaplanning/issues/133

Changes:
- Fixed the logic to get the last used model for each conversation (was using lowercase GUID, but DB stores in uppercase :))
- Added a test for this behavior
- Updated some test dependencies

Note: xUnit v2 is deprecated, but to move to xUnit.v3, we need to update to Avalonia 12.